### PR TITLE
1.17.1-mod.2025.6: Update fontkit for enhancing UVS support runtime performance

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,5 +1,9 @@
 # Modifications
 
+## [1.17.1-mod.2025.6]
+
+- Update `@denkiyagi/fontkit` to `2.0.4-mod.2025.2`, which enhances runtime performance for Unicode Variation Sequences (UVS) support.
+
 ## [1.17.1-mod.2025.5]
 
 - Update `@denkiyagi/fontkit` to `2.0.4-mod.2025.1`, which improves Unicode Variation Sequences (UVS) support.

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "yarn.lock"
   ],
   "dependencies": {
-    "@denkiyagi/fontkit": "2.0.4-mod.2025.1",
+    "@denkiyagi/fontkit": "2.0.4-mod.2025.2",
     "@pdf-lib/standard-fonts": "^1.0.0",
     "@pdf-lib/upng": "^1.0.1",
     "crypto-js": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denkiyagi/pdf-lib",
-  "version": "1.17.1-mod.2025.5",
+  "version": "1.17.1-mod.2025.6",
   "description": "A modified version of pdf-lib. Create and modify PDF files with JavaScript",
   "author": "DenkiYagi Inc. (modified version author), Andrew Dillon <andrew.dillon.j@gmail.com> (orignal version author)",
   "contributors": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -293,10 +293,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@denkiyagi/fontkit@2.0.4-mod.2025.1":
-  version "2.0.4-mod.2025.1"
-  resolved "https://npm.pkg.github.com/download/@denkiyagi/fontkit/2.0.4-mod.2025.1/fa6e2345ac480958cae1d1b419af76cca101af47#fa6e2345ac480958cae1d1b419af76cca101af47"
-  integrity sha512-KOWnvKNtMYnMLAr5GN5s9vXaS/oCTB/q3puQb2LlooGzN0NBfZVyh4VLYuy/6y1Nhhx5ouDd35vpv+I5AWbejg==
+"@denkiyagi/fontkit@2.0.4-mod.2025.2":
+  version "2.0.4-mod.2025.2"
+  resolved "https://npm.pkg.github.com/download/@denkiyagi/fontkit/2.0.4-mod.2025.2/55d8cac83d16580b2380be95d6ec8adcf7f16f7b#55d8cac83d16580b2380be95d6ec8adcf7f16f7b"
+  integrity sha512-VlG6bWdM6vKzwMbpHmbPaQW0FQph8IMv6d/K/X85dqBghx7XSf1L+QmuG54sXovROgFf5sazd6YMURWbf1laWw==
   dependencies:
     "@swc/helpers" "^0.5.12"
     brotli "^1.3.2"


### PR DESCRIPTION
- Update `@denkiyagi/fontkit` to `2.0.4-mod.2025.2`, which enhances runtime performance for Unicode Variation Sequences (UVS) support.
- Update version of this library `@denkiyagi/pdf-lib` to `1.17.1-mod.2025.6`.