### PR TITLE
APIが出しうる例外を pdf-lib 独自のエラークラスに統一

### DIFF
--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,6 +1,6 @@
 # Modifications
 
-## [Unreleased]
+## [1.17.1-mod.2025.8]
 
 ### Feature Removals
 

--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -11,6 +11,12 @@
 - Remove Base64 output by removing the `PDFDocument#saveAsBase64` method;
   use `PDFDocument#save` which resolves a `Uint8Array` instead.
 
+### Error Handling
+
+- Introduced `PDFLibError` (exported from `src/core`) with a machine-readable `type: PDFLibErrorType` to classify errors.
+- Refactored API/core/utils errors so that all errors extend `PDFLibError` instead of throwing bare `Error`/`TypeError`.
+- Normalize external failure surfaces by catching `@denkiyagi/fontkit` and `@pdf-lib/upng` exceptions and rethrowing corresponding `PDFLibError` subclasses (e.g., `InvalidFontDataError`) instead of leaking third-party errors.
+
 ### Internal Changes
 
 - Update several devDependencies including `typescript` to their latest versions.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denkiyagi/pdf-lib",
-  "version": "1.17.1-mod.2025.7",
+  "version": "1.17.1-mod.2025.8",
   "description": "A modified version of pdf-lib. Create and modify PDF files with JavaScript",
   "author": "DenkiYagi Inc. (modified version author), Andrew Dillon <andrew.dillon.j@gmail.com> (orignal version author)",
   "contributors": [

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -3,6 +3,7 @@ import type { Embeddable } from 'src/api/Embeddable';
 import {
   EncryptedPDFError,
   ForeignPageError,
+  InvalidFontSubsetOptionError,
   RemovePageFromEmptyDocumentError,
 } from 'src/api/errors';
 import { PDFEmbeddedPage } from 'src/api/PDFEmbeddedPage';
@@ -11,7 +12,7 @@ import { PDFImage } from 'src/api/PDFImage';
 import { PDFPage } from 'src/api/PDFPage';
 import { PDFForm } from 'src/api/form/PDFForm';
 import { PageSizes } from 'src/api/sizes';
-import type { StandardFonts } from 'src/api/StandardFonts';
+import { StandardFonts } from 'src/api/StandardFonts';
 import {
   AbstractCustomFontEmbedder,
   CustomFontEmbedder,
@@ -50,6 +51,8 @@ import type { PDFObject } from 'src/core/objects/PDFObject';
 import type { PDFRef } from 'src/core/objects/PDFRef';
 import type { TransformationMatrix } from 'src/types/matrix';
 import {
+  InvalidOptionPassedError,
+  InvalidTypePassedError,
   assertIs,
   assertIsOneOfOrUndefined,
   assertOrUndefined,
@@ -60,6 +63,7 @@ import {
   pluckIndices,
   range,
   toUint8Array,
+  values,
 } from 'src/utils';
 import { FileEmbedder, AFRelationship } from 'src/core/embedders/FileEmbedder';
 import { PDFEmbeddedFile } from 'src/api/PDFEmbeddedFile';
@@ -880,8 +884,10 @@ export class PDFDocument {
         ? CustomFontSubsetEmbedder.for(bytes, customName, vertical, advanced)
         : CustomFontEmbedder.for(bytes, customName, vertical, advanced);
     } else {
-      throw new TypeError(
-        '`font` must be one of `StandardFonts | Uint8Array | ArrayBuffer`',
+      throw new InvalidTypePassedError(
+        'font',
+        ['string', Uint8Array, ArrayBuffer],
+        font,
       );
     }
 
@@ -906,9 +912,7 @@ export class PDFDocument {
   embedTTFFont(font: TTFFont, options: EmbedFontOptions): PDFFont {
     const { subset, customName, vertical, advanced } = options;
     if (subset !== true) {
-      throw new TypeError(
-        '`subset` must explicitly be true when embedding a TTFFont',
-      );
+      throw new InvalidFontSubsetOptionError(subset);
     }
 
     const embedder = CustomFontSubsetEmbedder.forTTFFont(
@@ -939,7 +943,7 @@ export class PDFDocument {
   embedStandardFont(font: StandardFonts, customName?: string): PDFFont {
     assertIs(font, 'font', ['string']);
     if (!isStandardFont(font)) {
-      throw new TypeError('`font` must be one of type `StandardFonts`');
+      throw new InvalidOptionPassedError('font', values(StandardFonts), font);
     }
 
     const embedder = StandardFontEmbedder.for(font, customName);

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -38,6 +38,7 @@ import {
   StandardFontEmbedder,
   UnexpectedObjectTypeError,
 } from 'src/core';
+import { mapFontkitError } from 'src/core/embedders/fontkit-helpers';
 import {
   ParseSpeeds,
   AttachmentOptions,
@@ -880,9 +881,15 @@ export class PDFDocument {
       embedder = StandardFontEmbedder.for(font, customName);
     } else if (canBeConvertedToUint8Array(font)) {
       const bytes = toUint8Array(font);
-      embedder = subset
-        ? CustomFontSubsetEmbedder.for(bytes, customName, vertical, advanced)
-        : CustomFontEmbedder.for(bytes, customName, vertical, advanced);
+      try {
+        embedder = subset
+          ? CustomFontSubsetEmbedder.for(bytes, customName, vertical, advanced)
+          : CustomFontEmbedder.for(bytes, customName, vertical, advanced);
+      } catch (error) {
+        const mappedError = mapFontkitError(error);
+        if (mappedError) throw mappedError;
+        throw error;
+      }
     } else {
       throw new InvalidTypePassedError(
         'font',
@@ -915,12 +922,19 @@ export class PDFDocument {
       throw new InvalidFontSubsetOptionError(subset);
     }
 
-    const embedder = CustomFontSubsetEmbedder.forTTFFont(
-      font,
-      customName,
-      vertical,
-      advanced,
-    );
+    let embedder: AbstractCustomFontEmbedder;
+    try {
+      embedder = CustomFontSubsetEmbedder.forTTFFont(
+        font,
+        customName,
+        vertical,
+        advanced,
+      );
+    } catch (error) {
+      const mappedError = mapFontkitError(error);
+      if (mappedError) throw mappedError;
+      throw error;
+    }
 
     const ref = this.context.nextRef();
     const pdfFont = PDFFont.of(ref, this, embedder);

--- a/src/api/PDFFont.ts
+++ b/src/api/PDFFont.ts
@@ -8,6 +8,7 @@ import {
   PDFRef,
   StandardFontEmbedder,
 } from 'src/core';
+import { mapFontkitError } from 'src/core/embedders/fontkit-helpers';
 import type { SingleLineTextOrGlyphs } from 'src/types/text';
 import { assertIs, assertOrUndefined } from 'src/utils';
 
@@ -76,7 +77,13 @@ export class PDFFont implements Embeddable {
   ): PDFHexString {
     assertIs(text, 'text', ['string', Array, Uint16Array, Uint32Array]);
     this.modified = true;
-    return this.embedder.encodeText(text, layoutAdvancedParams);
+    try {
+      return this.embedder.encodeText(text, layoutAdvancedParams);
+    } catch (error) {
+      const mappedError = mapFontkitError(error);
+      if (mappedError) throw mappedError;
+      throw error;
+    }
   }
 
   /**
@@ -93,7 +100,13 @@ export class PDFFont implements Embeddable {
   widthOfTextAtSize(text: string, size: number): number {
     assertIs(text, 'text', ['string']);
     assertIs(size, 'size', ['number']);
-    return this.embedder.widthOfTextAtSize(text, size);
+    try {
+      return this.embedder.widthOfTextAtSize(text, size);
+    } catch (error) {
+      const mappedError = mapFontkitError(error);
+      if (mappedError) throw mappedError;
+      throw error;
+    }
   }
 
   /**
@@ -173,7 +186,13 @@ export class PDFFont implements Embeddable {
   async embed(): Promise<void> {
     // TODO: Cleanup orphan embedded objects if a font is embedded multiple times...
     if (this.modified) {
-      await this.embedder.embedIntoContext(this.doc.context, this.ref);
+      try {
+        this.embedder.embedIntoContext(this.doc.context, this.ref);
+      } catch (error) {
+        const mappedError = mapFontkitError(error);
+        if (mappedError) throw mappedError;
+        throw error;
+      }
       this.modified = false;
     }
   }

--- a/src/api/colors.ts
+++ b/src/api/colors.ts
@@ -6,6 +6,7 @@ import {
   setStrokingGrayscaleColor,
   setStrokingRgbColor,
 } from 'src/api/operators';
+import { InvalidColorError } from 'src/api/errors';
 import { assertRange } from 'src/utils';
 
 export enum ColorTypes {
@@ -77,7 +78,7 @@ export const setFillingColor = (color: Color) => {
         color.key,
       );
     default:
-      throw new Error(`Invalid color: ${JSON.stringify(color)}`);
+      throw new InvalidColorError(color);
   }
 };
 
@@ -95,7 +96,7 @@ export const setStrokingColor = (color: Color) => {
         color.key,
       );
     default:
-      throw new Error(`Invalid color: ${JSON.stringify(color)}`);
+      throw new InvalidColorError(color);
   }
 };
 
@@ -127,6 +128,6 @@ export const colorToComponents = (color: Color) => {
     case CMYK:
       return [color.cyan, color.magenta, color.yellow, color.key];
     default:
-      throw new Error(`Invalid color: ${JSON.stringify(color)}`);
+      throw new InvalidColorError(color);
   }
 };

--- a/src/api/colors.ts
+++ b/src/api/colors.ts
@@ -6,7 +6,7 @@ import {
   setStrokingGrayscaleColor,
   setStrokingRgbColor,
 } from 'src/api/operators';
-import { assertRange, error } from 'src/utils';
+import { assertRange } from 'src/utils';
 
 export enum ColorTypes {
   Grayscale = 'Grayscale',
@@ -63,19 +63,41 @@ export const cmyk = (
 
 const { Grayscale, RGB, CMYK } = ColorTypes;
 
-// prettier-ignore
-export const setFillingColor = (color: Color) => 
-    color.type === Grayscale ? setFillingGrayscaleColor(color.gray)
-  : color.type === RGB       ? setFillingRgbColor(color.red, color.green, color.blue)
-  : color.type === CMYK      ? setFillingCmykColor(color.cyan, color.magenta, color.yellow, color.key)
-  : error(`Invalid color: ${JSON.stringify(color)}`);
+export const setFillingColor = (color: Color) => {
+  switch (color.type) {
+    case Grayscale:
+      return setFillingGrayscaleColor(color.gray);
+    case RGB:
+      return setFillingRgbColor(color.red, color.green, color.blue);
+    case CMYK:
+      return setFillingCmykColor(
+        color.cyan,
+        color.magenta,
+        color.yellow,
+        color.key,
+      );
+    default:
+      throw new Error(`Invalid color: ${JSON.stringify(color)}`);
+  }
+};
 
-// prettier-ignore
-export const setStrokingColor = (color: Color) => 
-    color.type === Grayscale ? setStrokingGrayscaleColor(color.gray)
-  : color.type === RGB       ? setStrokingRgbColor(color.red, color.green, color.blue)
-  : color.type === CMYK      ? setStrokingCmykColor(color.cyan, color.magenta, color.yellow, color.key)
-  : error(`Invalid color: ${JSON.stringify(color)}`);
+export const setStrokingColor = (color: Color) => {
+  switch (color.type) {
+    case Grayscale:
+      return setStrokingGrayscaleColor(color.gray);
+    case RGB:
+      return setStrokingRgbColor(color.red, color.green, color.blue);
+    case CMYK:
+      return setStrokingCmykColor(
+        color.cyan,
+        color.magenta,
+        color.yellow,
+        color.key,
+      );
+    default:
+      throw new Error(`Invalid color: ${JSON.stringify(color)}`);
+  }
+};
 
 // prettier-ignore
 export const componentsToColor = (comps?: number[], scale = 1) => (
@@ -96,9 +118,15 @@ export const componentsToColor = (comps?: number[], scale = 1) => (
   : undefined
 );
 
-// prettier-ignore
-export const colorToComponents = (color: Color) =>
-    color.type === Grayscale ? [color.gray]
-  : color.type === RGB       ? [color.red, color.green, color.blue]
-  : color.type === CMYK      ? [color.cyan, color.magenta, color.yellow, color.key]
-  : error(`Invalid color: ${JSON.stringify(color)}`);
+export const colorToComponents = (color: Color) => {
+  switch (color.type) {
+    case Grayscale:
+      return [color.gray];
+    case RGB:
+      return [color.red, color.green, color.blue];
+    case CMYK:
+      return [color.cyan, color.magenta, color.yellow, color.key];
+    default:
+      throw new Error(`Invalid color: ${JSON.stringify(color)}`);
+  }
+};

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -90,3 +90,64 @@ export class InvalidMaxLengthError extends PDFLibAPIError {
     super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
+
+export class InvalidColorError extends PDFLibAPIError {
+  constructor(color: any) {
+    const msg = `Invalid color: ${JSON.stringify(color)}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidRotationError extends PDFLibAPIError {
+  constructor(rotation: any) {
+    const msg = `Invalid rotation: ${JSON.stringify(rotation)}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidFontSubsetOptionError extends PDFLibAPIError {
+  constructor(actual: any) {
+    const msg =
+      `\`subset\` must explicitly be true when embedding a TTFFont, ` +
+      `but was ${actual}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class MissingWidgetError extends PDFLibAPIError {
+  constructor(
+    reason: 'PDF_REF_FOR_OBJECT' | 'PAGE_FOR_REF',
+    ref?: { toString(): string },
+  ) {
+    let msg: string;
+    if (reason === 'PDF_REF_FOR_OBJECT') {
+      msg = 'Could not find PDFRef for PDFObject';
+    } else if (reason === 'PAGE_FOR_REF') {
+      msg = `Could not find page for PDFRef ${ref}`;
+    } else {
+      msg = 'Could not find widget';
+    }
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  }
+}
+
+export class MissingAppearanceStreamError extends PDFLibAPIError {
+  constructor(fieldName: string) {
+    const msg = `Failed to extract appearance ref for: ${fieldName}`;
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  }
+}
+
+export class InvalidFieldNameError extends PDFLibAPIError {
+  constructor(reason: 'EMPTY' | 'ADJACENT_PERIODS', fieldName: string) {
+    let msg: string;
+    if (reason === 'EMPTY') {
+      msg = 'PDF field names must not be empty strings';
+    } else if (reason === 'ADJACENT_PERIODS') {
+      msg = `Periods in PDF field names must be separated by at least one character: "${fieldName}"`;
+    } else {
+      msg = `Invalid PDF field name: "${fieldName}"`;
+    }
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,7 +1,11 @@
 // tslint:disable: max-classes-per-file
 
+import { PDFLibError } from 'src/core';
+
+export class PDFLibAPIError extends PDFLibError {}
+
 // TODO: Include link to documentation with example
-export class EncryptedPDFError extends Error {
+export class EncryptedPDFError extends PDFLibAPIError {
   constructor() {
     const msg =
       'Input document to `PDFDocument.load` is encrypted. You can use `PDFDocument.load(..., { ignoreEncryption: true })` if you wish to load the document anyways.';
@@ -10,7 +14,7 @@ export class EncryptedPDFError extends Error {
 }
 
 // TODO: Include link to documentation with example
-export class ForeignPageError extends Error {
+export class ForeignPageError extends PDFLibAPIError {
   constructor() {
     const msg =
       'A `page` passed to `PDFDocument.addPage` or `PDFDocument.insertPage` was from a different (foreign) PDF document. If you want to copy pages from one PDFDocument to another, you must use `PDFDocument.copyPages(...)` to copy the pages before adding or inserting them.';
@@ -19,7 +23,7 @@ export class ForeignPageError extends Error {
 }
 
 // TODO: Include link to documentation with example
-export class RemovePageFromEmptyDocumentError extends Error {
+export class RemovePageFromEmptyDocumentError extends PDFLibAPIError {
   constructor() {
     const msg =
       'PDFDocument has no pages so `PDFDocument.removePage` cannot be called';
@@ -27,14 +31,14 @@ export class RemovePageFromEmptyDocumentError extends Error {
   }
 }
 
-export class NoSuchFieldError extends Error {
+export class NoSuchFieldError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `PDFDocument has no form field with the name "${name}"`;
     super(msg);
   }
 }
 
-export class UnexpectedFieldTypeError extends Error {
+export class UnexpectedFieldTypeError extends PDFLibAPIError {
   constructor(name: string, expected: any, actual: any) {
     const expectedType = expected?.name;
     const actualType = actual?.constructor?.name ?? actual;
@@ -45,56 +49,56 @@ export class UnexpectedFieldTypeError extends Error {
   }
 }
 
-export class MissingOnValueCheckError extends Error {
+export class MissingOnValueCheckError extends PDFLibAPIError {
   constructor(onValue: any) {
     const msg = `Failed to select check box due to missing onValue: "${onValue}"`;
     super(msg);
   }
 }
 
-export class FieldAlreadyExistsError extends Error {
+export class FieldAlreadyExistsError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `A field already exists with the specified name: "${name}"`;
     super(msg);
   }
 }
 
-export class InvalidFieldNamePartError extends Error {
+export class InvalidFieldNamePartError extends PDFLibAPIError {
   constructor(namePart: string) {
     const msg = `Field name contains invalid component: "${namePart}"`;
     super(msg);
   }
 }
 
-export class FieldExistsAsNonTerminalError extends Error {
+export class FieldExistsAsNonTerminalError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `A non-terminal field already exists with the specified name: "${name}"`;
     super(msg);
   }
 }
 
-export class RichTextFieldReadError extends Error {
+export class RichTextFieldReadError extends PDFLibAPIError {
   constructor(fieldName: string) {
     const msg = `Reading rich text fields is not supported: Attempted to read rich text field: ${fieldName}`;
     super(msg);
   }
 }
 
-export class CombedTextLayoutError extends Error {
+export class CombedTextLayoutError extends PDFLibAPIError {
   constructor(lineLength: number, cellCount: number) {
     const msg = `Failed to layout combed text as lineLength=${lineLength} is greater than cellCount=${cellCount}`;
     super(msg);
   }
 }
 
-export class ExceededMaxLengthError extends Error {
+export class ExceededMaxLengthError extends PDFLibAPIError {
   constructor(textLength: number, maxLength: number, name: string) {
     const msg = `Attempted to set text with length=${textLength} for TextField with maxLength=${maxLength} and name=${name}`;
     super(msg);
   }
 }
 
-export class InvalidMaxLengthError extends Error {
+export class InvalidMaxLengthError extends PDFLibAPIError {
   constructor(textLength: number, maxLength: number, name: string) {
     const msg = `Attempted to set maxLength=${maxLength}, which is less than ${textLength}, the length of this field's current value (name=${name})`;
     super(msg);

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -49,13 +49,6 @@ export class UnexpectedFieldTypeError extends PDFLibAPIError {
   }
 }
 
-export class MissingOnValueCheckError extends PDFLibAPIError {
-  constructor(onValue: any) {
-    const msg = `Failed to select check box due to missing onValue: "${onValue}"`;
-    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
-  }
-}
-
 export class FieldAlreadyExistsError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `A field already exists with the specified name: "${name}"`;
@@ -66,13 +59,6 @@ export class FieldAlreadyExistsError extends PDFLibAPIError {
 export class InvalidFieldNamePartError extends PDFLibAPIError {
   constructor(namePart: string) {
     const msg = `Field name contains invalid component: "${namePart}"`;
-    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
-  }
-}
-
-export class FieldExistsAsNonTerminalError extends PDFLibAPIError {
-  constructor(name: string) {
-    const msg = `A non-terminal field already exists with the specified name: "${name}"`;
     super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }

--- a/src/api/errors.ts
+++ b/src/api/errors.ts
@@ -1,6 +1,6 @@
 // tslint:disable: max-classes-per-file
 
-import { PDFLibError } from 'src/core';
+import { PDFLibError, PDFLibErrorTypes } from 'src/core';
 
 export class PDFLibAPIError extends PDFLibError {}
 
@@ -9,7 +9,7 @@ export class EncryptedPDFError extends PDFLibAPIError {
   constructor() {
     const msg =
       'Input document to `PDFDocument.load` is encrypted. You can use `PDFDocument.load(..., { ignoreEncryption: true })` if you wish to load the document anyways.';
-    super(msg);
+    super(PDFLibErrorTypes.UNSUPPORTED_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
@@ -18,7 +18,7 @@ export class ForeignPageError extends PDFLibAPIError {
   constructor() {
     const msg =
       'A `page` passed to `PDFDocument.addPage` or `PDFDocument.insertPage` was from a different (foreign) PDF document. If you want to copy pages from one PDFDocument to another, you must use `PDFDocument.copyPages(...)` to copy the pages before adding or inserting them.';
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
@@ -27,14 +27,14 @@ export class RemovePageFromEmptyDocumentError extends PDFLibAPIError {
   constructor() {
     const msg =
       'PDFDocument has no pages so `PDFDocument.removePage` cannot be called';
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class NoSuchFieldError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `PDFDocument has no form field with the name "${name}"`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
@@ -45,62 +45,62 @@ export class UnexpectedFieldTypeError extends PDFLibAPIError {
     const msg =
       `Expected field "${name}" to be of type ${expectedType}, ` +
       `but it is actually of type ${actualType}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class MissingOnValueCheckError extends PDFLibAPIError {
   constructor(onValue: any) {
     const msg = `Failed to select check box due to missing onValue: "${onValue}"`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class FieldAlreadyExistsError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `A field already exists with the specified name: "${name}"`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class InvalidFieldNamePartError extends PDFLibAPIError {
   constructor(namePart: string) {
     const msg = `Field name contains invalid component: "${namePart}"`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class FieldExistsAsNonTerminalError extends PDFLibAPIError {
   constructor(name: string) {
     const msg = `A non-terminal field already exists with the specified name: "${name}"`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class RichTextFieldReadError extends PDFLibAPIError {
   constructor(fieldName: string) {
     const msg = `Reading rich text fields is not supported: Attempted to read rich text field: ${fieldName}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class CombedTextLayoutError extends PDFLibAPIError {
   constructor(lineLength: number, cellCount: number) {
     const msg = `Failed to layout combed text as lineLength=${lineLength} is greater than cellCount=${cellCount}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class ExceededMaxLengthError extends PDFLibAPIError {
   constructor(textLength: number, maxLength: number, name: string) {
     const msg = `Attempted to set text with length=${textLength} for TextField with maxLength=${maxLength} and name=${name}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class InvalidMaxLengthError extends PDFLibAPIError {
   constructor(textLength: number, maxLength: number, name: string) {
     const msg = `Attempted to set maxLength=${maxLength}, which is less than ${textLength}, the length of this field's current value (name=${name})`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }

--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -13,6 +13,9 @@ import {
   UnexpectedFieldTypeError,
   FieldAlreadyExistsError,
   InvalidFieldNamePartError,
+  InvalidFieldNameError,
+  MissingAppearanceStreamError,
+  MissingWidgetError,
 } from 'src/api/errors';
 import { PDFFont } from 'src/api/PDFFont';
 import { StandardFonts } from 'src/api/StandardFonts';
@@ -704,13 +707,13 @@ export class PDFForm {
     if (page === undefined) {
       const widgetRef = this.doc.context.getObjectRef(widget.dict);
       if (widgetRef === undefined) {
-        throw new Error('Could not find PDFRef for PDFObject');
+        throw new MissingWidgetError('PDF_REF_FOR_OBJECT');
       }
 
       page = this.doc.findPageForAnnotationRef(widgetRef);
 
       if (page === undefined) {
-        throw new Error(`Could not find page for PDFRef ${widgetRef}`);
+        throw new MissingWidgetError('PAGE_FOR_REF', widgetRef);
       }
     }
 
@@ -737,7 +740,7 @@ export class PDFForm {
 
     if (!(refOrDict instanceof PDFRef)) {
       const name = field.getName();
-      throw new Error(`Failed to extract appearance ref for: ${name}`);
+      throw new MissingAppearanceStreamError(name);
     }
 
     return refOrDict;
@@ -812,16 +815,14 @@ const convertToPDFField = (
 
 const splitFieldName = (fullyQualifiedName: string) => {
   if (fullyQualifiedName.length === 0) {
-    throw new Error('PDF field names must not be empty strings');
+    throw new InvalidFieldNameError('EMPTY', fullyQualifiedName);
   }
 
   const parts = fullyQualifiedName.split('.');
 
   for (let idx = 0, len = parts.length; idx < len; idx++) {
     if (parts[idx] === '') {
-      throw new Error(
-        `Periods in PDF field names must be separated by at least one character: "${fullyQualifiedName}"`,
-      );
+      throw new InvalidFieldNameError('ADJACENT_PERIODS', fullyQualifiedName);
     }
   }
 

--- a/src/api/rotations.ts
+++ b/src/api/rotations.ts
@@ -1,3 +1,4 @@
+import { InvalidRotationError } from 'src/api/errors';
 import { assertIs } from 'src/utils';
 
 export enum RotationTypes {
@@ -39,7 +40,7 @@ export const toRadians = (rotation: Rotation) => {
     case Degrees:
       return degreesToRadians(rotation.angle);
     default:
-      throw new Error(`Invalid rotation: ${JSON.stringify(rotation)}`);
+      throw new InvalidRotationError(rotation);
   }
 };
 
@@ -50,7 +51,7 @@ export const toDegrees = (rotation: Rotation) => {
     case Degrees:
       return rotation.angle;
     default:
-      throw new Error(`Invalid rotation: ${JSON.stringify(rotation)}`);
+      throw new InvalidRotationError(rotation);
   }
 };
 

--- a/src/api/rotations.ts
+++ b/src/api/rotations.ts
@@ -1,4 +1,4 @@
-import { assertIs, error } from 'src/utils';
+import { assertIs } from 'src/utils';
 
 export enum RotationTypes {
   Degrees = 'degrees',
@@ -32,17 +32,27 @@ const { Radians, Degrees } = RotationTypes;
 export const degreesToRadians = (degree: number) => (degree * Math.PI) / 180;
 export const radiansToDegrees = (radian: number) => (radian * 180) / Math.PI;
 
-// prettier-ignore
-export const toRadians = (rotation: Rotation) => 
-    rotation.type === Radians ? rotation.angle
-  : rotation.type === Degrees ? degreesToRadians(rotation.angle)
-  : error(`Invalid rotation: ${JSON.stringify(rotation)}`);
+export const toRadians = (rotation: Rotation) => {
+  switch (rotation.type) {
+    case Radians:
+      return rotation.angle;
+    case Degrees:
+      return degreesToRadians(rotation.angle);
+    default:
+      throw new Error(`Invalid rotation: ${JSON.stringify(rotation)}`);
+  }
+};
 
-// prettier-ignore
-export const toDegrees = (rotation: Rotation) => 
-    rotation.type === Radians ? radiansToDegrees(rotation.angle)
-  : rotation.type === Degrees ? rotation.angle
-  : error(`Invalid rotation: ${JSON.stringify(rotation)}`);
+export const toDegrees = (rotation: Rotation) => {
+  switch (rotation.type) {
+    case Radians:
+      return radiansToDegrees(rotation.angle);
+    case Degrees:
+      return rotation.angle;
+    default:
+      throw new Error(`Invalid rotation: ${JSON.stringify(rotation)}`);
+  }
+};
 
 export const reduceRotation = (degreeAngle = 0) => {
   const quadrants = (degreeAngle / 90) % 4;

--- a/src/core/acroform/PDFAcroForm.ts
+++ b/src/core/acroform/PDFAcroForm.ts
@@ -9,6 +9,7 @@ import {
   createPDFAcroField,
   createPDFAcroFields,
 } from 'src/core/acroform/utils';
+import { MissingAcroFormFieldError } from 'src/core/errors';
 
 export class PDFAcroForm {
   readonly dict: PDFDict;
@@ -75,9 +76,8 @@ export class PDFAcroForm {
 
     const index = fields?.indexOf(field.ref);
     if (fields === undefined || index === undefined) {
-      throw new Error(
-        `Tried to remove inexistent field ${field.getFullyQualifiedName()}`,
-      );
+      const fieldName = field.getFullyQualifiedName() ?? '<unknown field>';
+      throw new MissingAcroFormFieldError(fieldName);
     }
 
     fields.remove(index);

--- a/src/core/annotation/PDFAnnotation.ts
+++ b/src/core/annotation/PDFAnnotation.ts
@@ -4,6 +4,7 @@ import { PDFStream } from 'src/core/objects/PDFStream';
 import { PDFArray } from 'src/core/objects/PDFArray';
 import { PDFRef } from 'src/core/objects/PDFRef';
 import { PDFNumber } from 'src/core/objects/PDFNumber';
+import { UnexpectedAppearanceTypeError } from 'src/core/errors';
 
 export class PDFAnnotation {
   readonly dict: PDFDict;
@@ -67,7 +68,7 @@ export class PDFAnnotation {
     const N = AP.get(PDFName.of('N'));
     if (N instanceof PDFRef || N instanceof PDFDict) return N;
 
-    throw new Error(`Unexpected N type: ${N?.constructor.name}`);
+    throw new UnexpectedAppearanceTypeError(N);
   }
 
   /** @param appearance A PDFDict or PDFStream (direct or ref) */

--- a/src/core/embedders/CMap.ts
+++ b/src/core/embedders/CMap.ts
@@ -1,6 +1,8 @@
 import type { Glyph } from '@denkiyagi/fontkit';
 
-import { toHexString, toHexStringOfMinLength } from 'src/utils';
+import { InvalidUnicodeCodePointError } from 'src/core/errors';
+import { PDFLibErrorTypes } from 'src/core/error-base';
+import { toHexStringOfMinLength } from 'src/utils';
 import {
   hasSurrogates,
   highSurrogate,
@@ -64,7 +66,9 @@ const cmapCodePointFormat = (codePoint: number) => {
     return `${cmapHexString(hs)}${cmapHexString(ls)}`;
   }
 
-  const hex = toHexString(codePoint);
-  const msg = `0x${hex} is not a valid UTF-8 or UTF-16 codepoint.`;
-  throw new Error(msg);
+  throw new InvalidUnicodeCodePointError(
+    codePoint,
+    PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA,
+    'not a valid UTF-8 or UTF-16 codepoint',
+  );
 };

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -3,6 +3,7 @@ import type { TTFFont } from '@denkiyagi/fontkit';
 
 import { AbstractCustomFontEmbedder } from 'src/core/embedders/AbstractCustomFontEmbedder';
 import { InvalidFontTypeError } from 'src/core/errors';
+import { mapFontkitError } from 'src/core/embedders/fontkit-helpers';
 import type { EmbedFontAdvancedOptions } from 'src/api';
 
 export class CustomFontEmbedder extends AbstractCustomFontEmbedder {
@@ -12,7 +13,13 @@ export class CustomFontEmbedder extends AbstractCustomFontEmbedder {
     vertical?: boolean,
     advanced?: EmbedFontAdvancedOptions,
   ) {
-    const font = createFont(fontData);
+    let font;
+    try {
+      font = createFont(fontData);
+    } catch (error) {
+      throw mapFontkitError(error);
+    }
+
     if (font.type !== 'TTF') throw new InvalidFontTypeError(font.type);
     return new CustomFontEmbedder(
       font,

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -3,7 +3,6 @@ import type { TTFFont } from '@denkiyagi/fontkit';
 
 import { AbstractCustomFontEmbedder } from 'src/core/embedders/AbstractCustomFontEmbedder';
 import { InvalidFontTypeError } from 'src/core/errors';
-import { mapFontkitError } from 'src/core/embedders/fontkit-helpers';
 import type { EmbedFontAdvancedOptions } from 'src/api';
 
 export class CustomFontEmbedder extends AbstractCustomFontEmbedder {
@@ -13,13 +12,7 @@ export class CustomFontEmbedder extends AbstractCustomFontEmbedder {
     vertical?: boolean,
     advanced?: EmbedFontAdvancedOptions,
   ) {
-    let font;
-    try {
-      font = createFont(fontData);
-    } catch (error) {
-      throw mapFontkitError(error);
-    }
-
+    const font = createFont(fontData);
     if (font.type !== 'TTF') throw new InvalidFontTypeError(font.type);
     return new CustomFontEmbedder(
       font,

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -2,6 +2,7 @@ import { create as createFont } from '@denkiyagi/fontkit';
 import type { TTFFont } from '@denkiyagi/fontkit';
 
 import { AbstractCustomFontEmbedder } from 'src/core/embedders/AbstractCustomFontEmbedder';
+import { InvalidFontTypeError } from 'src/core/errors';
 import type { EmbedFontAdvancedOptions } from 'src/api';
 
 export class CustomFontEmbedder extends AbstractCustomFontEmbedder {
@@ -12,7 +13,7 @@ export class CustomFontEmbedder extends AbstractCustomFontEmbedder {
     advanced?: EmbedFontAdvancedOptions,
   ) {
     const font = createFont(fontData);
-    if (font.type !== 'TTF') throw new Error(`Invalid font type: ${font.type}`);
+    if (font.type !== 'TTF') throw new InvalidFontTypeError(font.type);
     return new CustomFontEmbedder(
       font,
       fontData,

--- a/src/core/embedders/CustomFontSubsetEmbedder.ts
+++ b/src/core/embedders/CustomFontSubsetEmbedder.ts
@@ -3,6 +3,7 @@ import type { TTFFont, Glyph, Subset } from '@denkiyagi/fontkit';
 
 import { AbstractCustomFontEmbedder } from 'src/core/embedders/AbstractCustomFontEmbedder';
 import { InvalidFontTypeError } from 'src/core/errors';
+import { mapFontkitError } from 'src/core/embedders/fontkit-helpers';
 import { PDFLibErrorTypes } from 'src/core/error-base';
 import { PDFHexString } from 'src/core/objects/PDFHexString';
 import { Cache, toHexStringOfMinLength } from 'src/utils';
@@ -21,7 +22,13 @@ export class CustomFontSubsetEmbedder extends AbstractCustomFontEmbedder {
     vertical?: boolean,
     advanced?: EmbedFontAdvancedOptions,
   ) {
-    const font = createFont(fontData);
+    let font;
+    try {
+      font = createFont(fontData);
+    } catch (error) {
+      throw mapFontkitError(error);
+    }
+
     if (font.type !== 'TTF') throw new InvalidFontTypeError(font.type);
 
     return new CustomFontSubsetEmbedder(

--- a/src/core/embedders/CustomFontSubsetEmbedder.ts
+++ b/src/core/embedders/CustomFontSubsetEmbedder.ts
@@ -2,6 +2,8 @@ import { create as createFont, LayoutAdvancedParams } from '@denkiyagi/fontkit';
 import type { TTFFont, Glyph, Subset } from '@denkiyagi/fontkit';
 
 import { AbstractCustomFontEmbedder } from 'src/core/embedders/AbstractCustomFontEmbedder';
+import { InvalidFontTypeError } from 'src/core/errors';
+import { PDFLibErrorTypes } from 'src/core/error-base';
 import { PDFHexString } from 'src/core/objects/PDFHexString';
 import { Cache, toHexStringOfMinLength } from 'src/utils';
 import type { EmbedFontAdvancedOptions } from 'src/api';
@@ -20,7 +22,7 @@ export class CustomFontSubsetEmbedder extends AbstractCustomFontEmbedder {
     advanced?: EmbedFontAdvancedOptions,
   ) {
     const font = createFont(fontData);
-    if (font.type !== 'TTF') throw new Error(`Invalid font type: ${font.type}`);
+    if (font.type !== 'TTF') throw new InvalidFontTypeError(font.type);
 
     return new CustomFontSubsetEmbedder(
       font,
@@ -36,7 +38,12 @@ export class CustomFontSubsetEmbedder extends AbstractCustomFontEmbedder {
     vertical?: boolean,
     advanced?: EmbedFontAdvancedOptions,
   ) {
-    if (font.type !== 'TTF') throw new Error(`Invalid font type: ${font.type}`);
+    if (font.type !== 'TTF') {
+      throw new InvalidFontTypeError(
+        font.type,
+        PDFLibErrorTypes.INVALID_CALLER_INPUT,
+      );
+    }
 
     return new CustomFontSubsetEmbedder(
       font,

--- a/src/core/embedders/CustomFontSubsetEmbedder.ts
+++ b/src/core/embedders/CustomFontSubsetEmbedder.ts
@@ -3,7 +3,6 @@ import type { TTFFont, Glyph, Subset } from '@denkiyagi/fontkit';
 
 import { AbstractCustomFontEmbedder } from 'src/core/embedders/AbstractCustomFontEmbedder';
 import { InvalidFontTypeError } from 'src/core/errors';
-import { mapFontkitError } from 'src/core/embedders/fontkit-helpers';
 import { PDFLibErrorTypes } from 'src/core/error-base';
 import { PDFHexString } from 'src/core/objects/PDFHexString';
 import { Cache, toHexStringOfMinLength } from 'src/utils';
@@ -22,13 +21,7 @@ export class CustomFontSubsetEmbedder extends AbstractCustomFontEmbedder {
     vertical?: boolean,
     advanced?: EmbedFontAdvancedOptions,
   ) {
-    let font;
-    try {
-      font = createFont(fontData);
-    } catch (error) {
-      throw mapFontkitError(error);
-    }
-
+    const font = createFont(fontData);
     if (font.type !== 'TTF') throw new InvalidFontTypeError(font.type);
 
     return new CustomFontSubsetEmbedder(

--- a/src/core/embedders/JpegEmbedder.ts
+++ b/src/core/embedders/JpegEmbedder.ts
@@ -1,3 +1,4 @@
+import { InvalidJpegError } from 'src/core/errors';
 import type { PDFRef } from 'src/core/objects/PDFRef';
 import type { PDFContext } from 'src/core/PDFContext';
 
@@ -32,7 +33,7 @@ export class JpegEmbedder {
     const dataView = new DataView(imageData.buffer);
 
     const soi = dataView.getUint16(0);
-    if (soi !== 0xffd8) throw new Error('SOI not found in JPEG');
+    if (soi !== 0xffd8) throw new InvalidJpegError('SOI_NOT_FOUND');
 
     let pos = 2;
     let marker: number;
@@ -44,7 +45,9 @@ export class JpegEmbedder {
       pos += dataView.getUint16(pos);
     }
 
-    if (!MARKERS.includes(marker!)) throw new Error('Invalid JPEG');
+    if (!MARKERS.includes(marker!)) {
+      throw new InvalidJpegError('INVALID_MARKER');
+    }
     pos += 2;
 
     const bitsPerComponent = dataView.getUint8(pos++);
@@ -57,7 +60,7 @@ export class JpegEmbedder {
     const channelByte = dataView.getUint8(pos++);
     const channelName = ChannelToColorSpace[channelByte];
 
-    if (!channelName) throw new Error('Unknown JPEG channel.');
+    if (!channelName) throw new InvalidJpegError('UNKNOWN_CHANNEL');
 
     const colorSpace = channelName;
 

--- a/src/core/embedders/fontkit-helpers.ts
+++ b/src/core/embedders/fontkit-helpers.ts
@@ -5,19 +5,21 @@ import {
   UnsupportedFontDataError as FontkitUnsupportedFontDataError,
   UnsupportedFontFileFormatError as FontkitUnsupportedFontFileFormatError,
 } from '@denkiyagi/fontkit';
-import { PDFLibError } from 'src/core/error-base';
 import {
   FontkitAssertionError as PDFLibFontkitAssertionError,
   InvalidFontDataError,
   UnsupportedFontDataError,
   UnsupportedFontFileFormatError,
 } from 'src/core/errors';
+import type { PDFLibError } from 'src/core/error-base';
 
 /**
  * Map known fontkit errors into the pdf-lib error family
  * so callers do not see raw fontkit exceptions.
+ *
+ * Returns `null` if the error is not recognized.
  */
-export const mapFontkitError = (error: unknown): PDFLibError => {
+export const mapFontkitError = (error: unknown): PDFLibError | null => {
   if (error instanceof FontkitUnsupportedFontFileFormatError) {
     return new UnsupportedFontFileFormatError(error.message);
   }
@@ -37,7 +39,5 @@ export const mapFontkitError = (error: unknown): PDFLibError => {
     return new PDFLibFontkitAssertionError(error.message);
   }
 
-  const msg =
-    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-  return new PDFLibFontkitAssertionError(`Unknown error: ${msg}`);
+  return null;
 };

--- a/src/core/embedders/fontkit-helpers.ts
+++ b/src/core/embedders/fontkit-helpers.ts
@@ -1,0 +1,43 @@
+import {
+  AssertionError as FontkitAssertionError,
+  InvalidCallerInputError as FontkitInvalidCallerInputError,
+  InvalidFontDataError as FontkitInvalidFontDataError,
+  UnsupportedFontDataError as FontkitUnsupportedFontDataError,
+  UnsupportedFontFileFormatError as FontkitUnsupportedFontFileFormatError,
+} from '@denkiyagi/fontkit';
+import { PDFLibError } from 'src/core/error-base';
+import {
+  FontkitAssertionError as PDFLibFontkitAssertionError,
+  InvalidFontDataError,
+  UnsupportedFontDataError,
+  UnsupportedFontFileFormatError,
+} from 'src/core/errors';
+
+/**
+ * Map known fontkit errors into the pdf-lib error family
+ * so callers do not see raw fontkit exceptions.
+ */
+export const mapFontkitError = (error: unknown): PDFLibError => {
+  if (error instanceof FontkitUnsupportedFontFileFormatError) {
+    return new UnsupportedFontFileFormatError(error.message);
+  }
+
+  if (error instanceof FontkitUnsupportedFontDataError) {
+    return new UnsupportedFontDataError(error.message);
+  }
+
+  if (error instanceof FontkitInvalidFontDataError) {
+    return new InvalidFontDataError(error.message);
+  }
+
+  if (
+    error instanceof FontkitInvalidCallerInputError ||
+    error instanceof FontkitAssertionError
+  ) {
+    return new PDFLibFontkitAssertionError(error.message);
+  }
+
+  const msg =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return new PDFLibFontkitAssertionError(`Unknown error: ${msg}`);
+};

--- a/src/core/error-base.ts
+++ b/src/core/error-base.ts
@@ -1,0 +1,10 @@
+/**
+ * Base class for all errors explicitly thrown by `@denkiyagi/pdf-lib`.
+ */
+export class PDFLibError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+
+    this.name = new.target.name;
+  }
+}

--- a/src/core/error-base.ts
+++ b/src/core/error-base.ts
@@ -1,10 +1,51 @@
 /**
+ * Error type codes recognized by `@denkiyagi/pdf-lib`.
+ */
+export const PDFLibErrorTypes = {
+  /**
+   * Function arguments/options outside the public contract
+   * (wrong type, invalid range, missing setup).
+   */
+  INVALID_CALLER_INPUT: 'INVALID_CALLER_INPUT',
+
+  /**
+   * Encoded data supplied from outside violates
+   * the relevant spec or is structurally corrupt.
+   */
+  INVALID_EXTERNAL_BINARY_DATA: 'INVALID_EXTERNAL_BINARY_DATA',
+
+  /**
+   * Data supplied from outside decodes successfully but requests
+   * features or formats we intentionally do not support.
+   */
+  UNSUPPORTED_EXTERNAL_BINARY_DATA: 'UNSUPPORTED_EXTERNAL_BINARY_DATA',
+
+  /**
+   * Invariant breach that should be unreachable if
+   * inputs and implementation are correct.
+   */
+  INTERNAL_ASSERTION: 'INTERNAL_ASSERTION',
+} as const;
+
+/**
+ * Error type code recognized by `@denkiyagi/pdf-lib`.
+ */
+export type PDFLibErrorType =
+  (typeof PDFLibErrorTypes)[keyof typeof PDFLibErrorTypes];
+
+/**
  * Base class for all errors explicitly thrown by `@denkiyagi/pdf-lib`.
  */
 export class PDFLibError extends Error {
-  constructor(message: string, options?: ErrorOptions) {
+  /**
+   * Machine-readable classification for the failure.
+   */
+  readonly type: PDFLibErrorType;
+
+  constructor(type: PDFLibErrorType, message: string, options?: ErrorOptions) {
     super(message, options);
 
     this.name = new.target.name;
+    this.type = type;
   }
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,22 +1,25 @@
 // tslint:disable: max-classes-per-file
 import type { PDFObject } from 'src/core/objects/PDFObject';
 import { arrayAsString } from 'src/utils';
+import { PDFLibError } from './error-base';
 
-export class MethodNotImplementedError extends Error {
+export class PDFLibCoreError extends PDFLibError {}
+
+export class MethodNotImplementedError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
     const msg = `Method ${className}.${methodName}() not implemented`;
     super(msg);
   }
 }
 
-export class PrivateConstructorError extends Error {
+export class PrivateConstructorError extends PDFLibCoreError {
   constructor(className: string) {
     const msg = `Cannot construct ${className} - it has a private constructor`;
     super(msg);
   }
 }
 
-export class UnexpectedObjectTypeError extends Error {
+export class UnexpectedObjectTypeError extends PDFLibCoreError {
   constructor(expected: any | any[], actual: any) {
     const name = (t: any) => t?.name ?? t?.constructor?.name;
 
@@ -32,35 +35,35 @@ export class UnexpectedObjectTypeError extends Error {
   }
 }
 
-export class UnsupportedEncodingError extends Error {
+export class UnsupportedEncodingError extends PDFLibCoreError {
   constructor(encoding: string) {
     const msg = `${encoding} stream encoding not supported`;
     super(msg);
   }
 }
 
-export class ReparseError extends Error {
+export class ReparseError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
     const msg = `Cannot call ${className}.${methodName}() more than once`;
     super(msg);
   }
 }
 
-export class MissingCatalogError extends Error {
+export class MissingCatalogError extends PDFLibCoreError {
   constructor(ref?: PDFObject) {
     const msg = `Missing catalog (ref=${ref})`;
     super(msg);
   }
 }
 
-export class MissingPageContentsEmbeddingError extends Error {
+export class MissingPageContentsEmbeddingError extends PDFLibCoreError {
   constructor() {
     const msg = `Can't embed page with missing Contents`;
     super(msg);
   }
 }
 
-export class UnrecognizedStreamTypeError extends Error {
+export class UnrecognizedStreamTypeError extends PDFLibCoreError {
   constructor(stream: any) {
     const streamType = stream?.contructor?.name ?? stream?.name ?? stream;
     const msg = `Unrecognized stream type: ${streamType}`;
@@ -68,70 +71,70 @@ export class UnrecognizedStreamTypeError extends Error {
   }
 }
 
-export class PageEmbeddingMismatchedContextError extends Error {
+export class PageEmbeddingMismatchedContextError extends PDFLibCoreError {
   constructor() {
     const msg = `Found mismatched contexts while embedding pages. All pages in the array passed to \`PDFDocument.embedPages()\` must be from the same document.`;
     super(msg);
   }
 }
 
-export class PDFArrayIsNotRectangleError extends Error {
+export class PDFArrayIsNotRectangleError extends PDFLibCoreError {
   constructor(size: number) {
     const msg = `Attempted to convert PDFArray with ${size} elements to rectangle, but must have exactly 4 elements.`;
     super(msg);
   }
 }
 
-export class InvalidPDFDateStringError extends Error {
+export class InvalidPDFDateStringError extends PDFLibCoreError {
   constructor(value: string) {
     const msg = `Attempted to convert "${value}" to a date, but it does not match the PDF date string format.`;
     super(msg);
   }
 }
 
-export class InvalidTargetIndexError extends Error {
+export class InvalidTargetIndexError extends PDFLibCoreError {
   constructor(targetIndex: number, Count: number) {
     const msg = `Invalid targetIndex specified: targetIndex=${targetIndex} must be less than Count=${Count}`;
     super(msg);
   }
 }
 
-export class CorruptPageTreeError extends Error {
+export class CorruptPageTreeError extends PDFLibCoreError {
   constructor(targetIndex: number, operation: string) {
     const msg = `Failed to ${operation} at targetIndex=${targetIndex} due to corrupt page tree: It is likely that one or more 'Count' entries are invalid`;
     super(msg);
   }
 }
 
-export class IndexOutOfBoundsError extends Error {
+export class IndexOutOfBoundsError extends PDFLibCoreError {
   constructor(index: number, min: number, max: number) {
     const msg = `index should be at least ${min} and at most ${max}, but was actually ${index}`;
     super(msg);
   }
 }
 
-export class InvalidAcroFieldValueError extends Error {
+export class InvalidAcroFieldValueError extends PDFLibCoreError {
   constructor() {
     const msg = `Attempted to set invalid field value`;
     super(msg);
   }
 }
 
-export class MultiSelectValueError extends Error {
+export class MultiSelectValueError extends PDFLibCoreError {
   constructor() {
     const msg = `Attempted to select multiple values for single-select field`;
     super(msg);
   }
 }
 
-export class MissingDAEntryError extends Error {
+export class MissingDAEntryError extends PDFLibCoreError {
   constructor(fieldName: string) {
     const msg = `No /DA (default appearance) entry found for field: ${fieldName}`;
     super(msg);
   }
 }
 
-export class MissingTfOperatorError extends Error {
+export class MissingTfOperatorError extends PDFLibCoreError {
   constructor(fieldName: string) {
     const msg = `No Tf operator found for DA of field: ${fieldName}`;
     super(msg);
@@ -146,7 +149,7 @@ export interface Position {
   offset: number;
 }
 
-export class NumberParsingError extends Error {
+export class NumberParsingError extends PDFLibCoreError {
   constructor(pos: Position, value: string) {
     const msg =
       `Failed to parse number ` +
@@ -155,7 +158,7 @@ export class NumberParsingError extends Error {
   }
 }
 
-export class PDFParsingError extends Error {
+export class PDFParsingError extends PDFLibCoreError {
   constructor(pos: Position, details: string) {
     const msg =
       `Failed to parse PDF document ` +

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -38,6 +38,30 @@ export class InvalidFontTypeError extends PDFLibCoreError {
   }
 }
 
+export class UnsupportedFontFileFormatError extends PDFLibCoreError {
+  constructor(message: string) {
+    super(PDFLibErrorTypes.UNSUPPORTED_EXTERNAL_BINARY_DATA, message);
+  }
+}
+
+export class UnsupportedFontDataError extends PDFLibCoreError {
+  constructor(message: string) {
+    super(PDFLibErrorTypes.UNSUPPORTED_EXTERNAL_BINARY_DATA, message);
+  }
+}
+
+export class InvalidFontDataError extends PDFLibCoreError {
+  constructor(message: string) {
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, message);
+  }
+}
+
+export class FontkitAssertionError extends PDFLibCoreError {
+  constructor(message: string) {
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, message);
+  }
+}
+
 export class MethodNotImplementedError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
     const msg = `Method ${className}.${methodName}() not implemented`;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,8 +1,42 @@
 // tslint:disable: max-classes-per-file
-import { arrayAsString } from 'src/utils';
-import { PDFLibError, PDFLibErrorTypes } from './error-base';
+
+import { arrayAsString } from 'src/utils/arrays';
+import { PDFLibError, PDFLibErrorType, PDFLibErrorTypes } from './error-base';
 
 export class PDFLibCoreError extends PDFLibError {}
+
+const formatCodePointHex = (codePoint: number) =>
+  codePoint.toString(16).toUpperCase().padStart(2, '0');
+
+export class InvalidUnicodeCodePointError extends PDFLibCoreError {
+  constructor(
+    codePoint: number,
+    originType: PDFLibErrorType = PDFLibErrorTypes.INTERNAL_ASSERTION,
+    reason?: string,
+  ) {
+    const hex = formatCodePointHex(codePoint);
+    const detail = reason ? ` (${reason})` : '';
+    const msg = `Invalid code point: 0x${hex}${detail}`;
+    super(originType, msg);
+  }
+}
+
+export class InvalidByteOrderError extends PDFLibCoreError {
+  constructor(byteOrder: number) {
+    const msg = `Invalid byteOrder: ${byteOrder}`;
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, msg);
+  }
+}
+
+export class InvalidFontTypeError extends PDFLibCoreError {
+  constructor(
+    fontType: string,
+    originType: PDFLibErrorType = PDFLibErrorTypes.UNSUPPORTED_EXTERNAL_BINARY_DATA,
+  ) {
+    const msg = `Invalid font type: ${fontType}`;
+    super(originType, msg);
+  }
+}
 
 export class MethodNotImplementedError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
@@ -130,6 +164,97 @@ export class MissingTfOperatorError extends PDFLibCoreError {
   constructor(fieldName: string) {
     const msg = `No Tf operator found for DA of field: ${fieldName}`;
     super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  }
+}
+
+export class MissingAcroFormFieldError extends PDFLibCoreError {
+  constructor(fieldName: string) {
+    const msg = `Tried to remove inexistent field ${fieldName}`;
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, msg);
+  }
+}
+
+export class InvalidIndirectObjectError extends PDFLibCoreError {
+  constructor(pos: Position) {
+    const msg = `Trying to parse invalid object: ${JSON.stringify(pos)})`;
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  }
+}
+
+export class UnexpectedAppearanceTypeError extends PDFLibCoreError {
+  constructor(actual: any) {
+    const msg = `Unexpected N type: ${actual?.constructor?.name ?? actual}`;
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  }
+}
+
+export type FlateDecodingErrorReason =
+  | 'INVALID_HEADER'
+  | 'UNKNOWN_COMPRESSION_METHOD'
+  | 'BAD_FCHECK'
+  | 'FDICT_SET'
+  | 'BAD_BLOCK_HEADER'
+  | 'BAD_UNCOMPRESSED_BLOCK_LENGTH'
+  | 'UNKNOWN_BLOCK_TYPE'
+  | 'BAD_ENCODING';
+
+export class FlateDecodingError extends PDFLibCoreError {
+  readonly reason: FlateDecodingErrorReason;
+
+  constructor(
+    reason: FlateDecodingErrorReason,
+    details?: { cmf?: number; flg?: number },
+  ) {
+    let msg: string;
+    if (reason === 'INVALID_HEADER') {
+      msg = `Invalid header in flate stream: ${details?.cmf}, ${details?.flg}`;
+    } else if (reason === 'UNKNOWN_COMPRESSION_METHOD') {
+      msg = `Unknown compression method in flate stream: ${details?.cmf}, ${details?.flg}`;
+    } else if (reason === 'BAD_FCHECK') {
+      msg = `Bad FCHECK in flate stream: ${details?.cmf}, ${details?.flg}`;
+    } else if (reason === 'FDICT_SET') {
+      msg = `FDICT bit set in flate stream: ${details?.cmf}, ${details?.flg}`;
+    } else if (reason === 'BAD_BLOCK_HEADER') {
+      msg = 'Bad block header in flate stream';
+    } else if (reason === 'BAD_UNCOMPRESSED_BLOCK_LENGTH') {
+      msg = 'Bad uncompressed block length in flate stream';
+    } else if (reason === 'UNKNOWN_BLOCK_TYPE') {
+      msg = 'Unknown block type in flate stream';
+    } else {
+      msg = 'Bad encoding in flate stream';
+    }
+
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+    this.reason = reason;
+  }
+}
+
+export class InvalidPasswordError extends PDFLibCoreError {
+  constructor() {
+    super(
+      PDFLibErrorTypes.INVALID_CALLER_INPUT,
+      'Password contains invalid characters.',
+    );
+  }
+}
+
+export type InvalidJpegReason =
+  | 'SOI_NOT_FOUND'
+  | 'INVALID_MARKER'
+  | 'UNKNOWN_CHANNEL';
+
+export class InvalidJpegError extends PDFLibCoreError {
+  readonly reason: InvalidJpegReason;
+
+  constructor(reason: InvalidJpegReason) {
+    let msg: string;
+    if (reason === 'SOI_NOT_FOUND') msg = 'SOI not found in JPEG';
+    else if (reason === 'INVALID_MARKER') msg = 'Invalid marker found in JPEG';
+    else if (reason === 'UNKNOWN_CHANNEL') msg = 'Unknown JPEG channel.';
+    else msg = 'Invalid JPEG';
+
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+    this.reason = reason;
   }
 }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,5 +1,4 @@
 // tslint:disable: max-classes-per-file
-import type { PDFObject } from 'src/core/objects/PDFObject';
 import { arrayAsString } from 'src/utils';
 import { PDFLibError, PDFLibErrorTypes } from './error-base';
 
@@ -46,13 +45,6 @@ export class ReparseError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
     const msg = `Cannot call ${className}.${methodName}() more than once`;
     super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
-  }
-}
-
-export class MissingCatalogError extends PDFLibCoreError {
-  constructor(ref?: PDFObject) {
-    const msg = `Missing catalog (ref=${ref})`;
-    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,21 +1,21 @@
 // tslint:disable: max-classes-per-file
 import type { PDFObject } from 'src/core/objects/PDFObject';
 import { arrayAsString } from 'src/utils';
-import { PDFLibError } from './error-base';
+import { PDFLibError, PDFLibErrorTypes } from './error-base';
 
 export class PDFLibCoreError extends PDFLibError {}
 
 export class MethodNotImplementedError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
     const msg = `Method ${className}.${methodName}() not implemented`;
-    super(msg);
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, msg);
   }
 }
 
 export class PrivateConstructorError extends PDFLibCoreError {
   constructor(className: string) {
     const msg = `Cannot construct ${className} - it has a private constructor`;
-    super(msg);
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, msg);
   }
 }
 
@@ -31,35 +31,35 @@ export class UnexpectedObjectTypeError extends PDFLibCoreError {
       `Expected instance of ${expectedTypes.join(' or ')}, ` +
       `but got instance of ${actual ? name(actual) : actual}`;
 
-    super(msg);
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, msg);
   }
 }
 
 export class UnsupportedEncodingError extends PDFLibCoreError {
   constructor(encoding: string) {
     const msg = `${encoding} stream encoding not supported`;
-    super(msg);
+    super(PDFLibErrorTypes.UNSUPPORTED_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
 export class ReparseError extends PDFLibCoreError {
   constructor(className: string, methodName: string) {
     const msg = `Cannot call ${className}.${methodName}() more than once`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class MissingCatalogError extends PDFLibCoreError {
   constructor(ref?: PDFObject) {
     const msg = `Missing catalog (ref=${ref})`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
 export class MissingPageContentsEmbeddingError extends PDFLibCoreError {
   constructor() {
     const msg = `Can't embed page with missing Contents`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
@@ -67,77 +67,77 @@ export class UnrecognizedStreamTypeError extends PDFLibCoreError {
   constructor(stream: any) {
     const streamType = stream?.contructor?.name ?? stream?.name ?? stream;
     const msg = `Unrecognized stream type: ${streamType}`;
-    super(msg);
+    super(PDFLibErrorTypes.INTERNAL_ASSERTION, msg);
   }
 }
 
 export class PageEmbeddingMismatchedContextError extends PDFLibCoreError {
   constructor() {
     const msg = `Found mismatched contexts while embedding pages. All pages in the array passed to \`PDFDocument.embedPages()\` must be from the same document.`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class PDFArrayIsNotRectangleError extends PDFLibCoreError {
   constructor(size: number) {
     const msg = `Attempted to convert PDFArray with ${size} elements to rectangle, but must have exactly 4 elements.`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
 export class InvalidPDFDateStringError extends PDFLibCoreError {
   constructor(value: string) {
     const msg = `Attempted to convert "${value}" to a date, but it does not match the PDF date string format.`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
 export class InvalidTargetIndexError extends PDFLibCoreError {
   constructor(targetIndex: number, Count: number) {
     const msg = `Invalid targetIndex specified: targetIndex=${targetIndex} must be less than Count=${Count}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class CorruptPageTreeError extends PDFLibCoreError {
   constructor(targetIndex: number, operation: string) {
     const msg = `Failed to ${operation} at targetIndex=${targetIndex} due to corrupt page tree: It is likely that one or more 'Count' entries are invalid`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
 export class IndexOutOfBoundsError extends PDFLibCoreError {
   constructor(index: number, min: number, max: number) {
     const msg = `index should be at least ${min} and at most ${max}, but was actually ${index}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class InvalidAcroFieldValueError extends PDFLibCoreError {
   constructor() {
     const msg = `Attempted to set invalid field value`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class MultiSelectValueError extends PDFLibCoreError {
   constructor() {
     const msg = `Attempted to select multiple values for single-select field`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
   }
 }
 
 export class MissingDAEntryError extends PDFLibCoreError {
   constructor(fieldName: string) {
     const msg = `No /DA (default appearance) entry found for field: ${fieldName}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
 export class MissingTfOperatorError extends PDFLibCoreError {
   constructor(fieldName: string) {
     const msg = `No Tf operator found for DA of field: ${fieldName}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
@@ -154,7 +154,7 @@ export class NumberParsingError extends PDFLibCoreError {
     const msg =
       `Failed to parse number ` +
       `(line:${pos.line} col:${pos.column} offset=${pos.offset}): "${value}"`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 
@@ -163,7 +163,7 @@ export class PDFParsingError extends PDFLibCoreError {
     const msg =
       `Failed to parse PDF document ` +
       `(line:${pos.line} col:${pos.column} offset=${pos.offset}): ${details}`;
-    super(msg);
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
   }
 }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,3 +1,4 @@
+export * from 'src/core/error-base';
 export * from 'src/core/errors';
 export { CharCodes } from 'src/core/syntax/CharCodes';
 

--- a/src/core/parser/PDFParser.ts
+++ b/src/core/parser/PDFParser.ts
@@ -4,6 +4,7 @@ import { PDFTrailer } from 'src/core/document/PDFTrailer';
 import {
   MissingKeywordError,
   MissingPDFHeaderError,
+  InvalidIndirectObjectError,
   PDFInvalidObjectParsingError,
   ReparseError,
   StalledParserError,
@@ -181,7 +182,9 @@ export class PDFParser extends PDFObjectParser {
     const startPos = this.bytes.position();
 
     const msg = `Trying to parse invalid object: ${JSON.stringify(startPos)})`;
-    if (this.throwOnInvalidObject) throw new Error(msg);
+    if (this.throwOnInvalidObject) {
+      throw new InvalidIndirectObjectError(startPos);
+    }
     console.warn(msg);
 
     const ref = this.parseIndirectObjectHeader();

--- a/src/core/security/StdSecurityHandlerR4.ts
+++ b/src/core/security/StdSecurityHandlerR4.ts
@@ -2,6 +2,7 @@ import {
   StdSecurityHandler,
   StdSecurityHandlerDict,
 } from 'src/core/security/StdSecurityHandler';
+import { InvalidPasswordError } from 'src/core/errors';
 import {
   MD5,
   encryptRC4,
@@ -201,7 +202,7 @@ const standardPaddingBytes = new Uint8Array([
  */
 const padOrTruncate32 = (s: string): WordArray => {
   if (!latin1Only.test(s)) {
-    throw new Error(`Password contains invalid characters.`);
+    throw new InvalidPasswordError();
   }
 
   const significantLength = Math.min(s.length, 32);

--- a/src/core/streams/FlateStream.ts
+++ b/src/core/streams/FlateStream.ts
@@ -15,6 +15,7 @@
  */
 
 /* tslint:disable  no-conditional-assignment */
+import { FlateDecodingError } from 'src/core/errors';
 import { DecodeStream } from 'src/core/streams/DecodeStream';
 import type { StreamType } from 'src/core/streams/Stream';
 
@@ -128,18 +129,16 @@ export class FlateStream extends DecodeStream {
     const cmf = stream.getByte();
     const flg = stream.getByte();
     if (cmf === -1 || flg === -1) {
-      throw new Error(`Invalid header in flate stream: ${cmf}, ${flg}`);
+      throw new FlateDecodingError('INVALID_HEADER', { cmf, flg });
     }
     if ((cmf & 0x0f) !== 0x08) {
-      throw new Error(
-        `Unknown compression method in flate stream: ${cmf}, ${flg}`,
-      );
+      throw new FlateDecodingError('UNKNOWN_COMPRESSION_METHOD', { cmf, flg });
     }
     if (((cmf << 8) + flg) % 31 !== 0) {
-      throw new Error(`Bad FCHECK in flate stream: ${cmf}, ${flg}`);
+      throw new FlateDecodingError('BAD_FCHECK', { cmf, flg });
     }
     if (flg & 0x20) {
-      throw new Error(`FDICT bit set in flate stream: ${cmf}, ${flg}`);
+      throw new FlateDecodingError('FDICT_SET', { cmf, flg });
     }
 
     this.codeSize = 0;
@@ -162,24 +161,24 @@ export class FlateStream extends DecodeStream {
       let b;
 
       if ((b = str.getByte()) === -1) {
-        throw new Error('Bad block header in flate stream');
+        throw new FlateDecodingError('BAD_BLOCK_HEADER');
       }
       let blockLen = b;
       if ((b = str.getByte()) === -1) {
-        throw new Error('Bad block header in flate stream');
+        throw new FlateDecodingError('BAD_BLOCK_HEADER');
       }
       blockLen |= b << 8;
       if ((b = str.getByte()) === -1) {
-        throw new Error('Bad block header in flate stream');
+        throw new FlateDecodingError('BAD_BLOCK_HEADER');
       }
       let check = b;
       if ((b = str.getByte()) === -1) {
-        throw new Error('Bad block header in flate stream');
+        throw new FlateDecodingError('BAD_BLOCK_HEADER');
       }
       check |= b << 8;
       if (check !== (~blockLen & 0xffff) && (blockLen !== 0 || check !== 0)) {
         // Ignoring error for bad "empty" block (see issue 1277)
-        throw new Error('Bad uncompressed block length in flate stream');
+        throw new FlateDecodingError('BAD_UNCOMPRESSED_BLOCK_LENGTH');
       }
 
       this.codeBuf = 0;
@@ -266,7 +265,7 @@ export class FlateStream extends DecodeStream {
         codeLengths.subarray(numLitCodes, codes),
       );
     } else {
-      throw new Error('Unknown block type in flate stream');
+      throw new FlateDecodingError('UNKNOWN_BLOCK_TYPE');
     }
 
     buffer = this.buffer;
@@ -318,7 +317,7 @@ export class FlateStream extends DecodeStream {
     let b;
     while (codeSize < bits) {
       if ((b = str.getByte()) === -1) {
-        throw new Error('Bad encoding in flate stream');
+        throw new FlateDecodingError('BAD_ENCODING');
       }
       codeBuf |= b << codeSize;
       codeSize += 8;
@@ -354,7 +353,7 @@ export class FlateStream extends DecodeStream {
     const codeLen = code >> 16;
     const codeVal = code & 0xffff;
     if (codeLen < 1 || codeSize < codeLen) {
-      throw new Error('Bad encoding in flate stream');
+      throw new FlateDecodingError('BAD_ENCODING');
     }
     this.codeBuf = codeBuf >> codeLen;
     this.codeSize = codeSize - codeLen;

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,4 +1,5 @@
 import { charFromCode } from 'src/utils/strings';
+import { InvalidInputTypeError } from 'src/utils/errors';
 
 export const last = <T>(array: T[]): T => array[array.length - 1];
 
@@ -114,7 +115,7 @@ export const canBeConvertedToUint8Array = (
 export const toUint8Array = (input: ArrayBuffer | Uint8Array) => {
   if (input instanceof ArrayBuffer) return new Uint8Array(input);
   if (input instanceof Uint8Array) return input;
-  throw new TypeError('`input` must be one of `ArrayBuffer | Uint8Array`');
+  throw new InvalidInputTypeError('input', 'ArrayBuffer | Uint8Array', input);
 };
 
 const byteToHex: string[] = [];

--- a/src/utils/arrays.ts
+++ b/src/utils/arrays.ts
@@ -1,5 +1,5 @@
 import { charFromCode } from 'src/utils/strings';
-import { InvalidInputTypeError } from 'src/utils/errors';
+import { InvalidTypePassedError } from 'src/utils/errors';
 
 export const last = <T>(array: T[]): T => array[array.length - 1];
 
@@ -115,7 +115,7 @@ export const canBeConvertedToUint8Array = (
 export const toUint8Array = (input: ArrayBuffer | Uint8Array) => {
   if (input instanceof ArrayBuffer) return new Uint8Array(input);
   if (input instanceof Uint8Array) return input;
-  throw new InvalidInputTypeError('input', 'ArrayBuffer | Uint8Array', input);
+  throw new InvalidTypePassedError('input', [ArrayBuffer, Uint8Array], input);
 };
 
 const byteToHex: string[] = [];

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,3 +1,0 @@
-export const error = (msg: string) => {
-  throw new Error(msg);
-};

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -40,15 +40,6 @@ const formatAllowedTypes = (types: TypeDescriptor[]) => {
   return allowedTypes.join(' or ');
 };
 
-export class InvalidInputTypeError extends PDFLibUtilsError {
-  constructor(valueName: string, expectedTypes: string, actual: any) {
-    const msg =
-      `${backtick(valueName)} must be one of ${expectedTypes}, ` +
-      `but was actually ${formatValue(actual)}`;
-    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
-  }
-}
-
 export class InvalidPngError extends PDFLibUtilsError {
   constructor(message: string) {
     super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, message);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -50,9 +50,8 @@ export class InvalidInputTypeError extends PDFLibUtilsError {
 }
 
 export class InvalidPngError extends PDFLibUtilsError {
-  constructor(ctype: number) {
-    const msg = `Unknown color type: ${ctype}`;
-    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  constructor(message: string) {
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, message);
   }
 }
 

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,126 @@
+// tslint:disable: max-classes-per-file
+
+import type { Primitive, TypeDescriptor } from 'src/utils/validators-helpers';
+import { getType } from 'src/utils/validators-helpers';
+import { PDFLibError, PDFLibErrorTypes } from 'src/core/error-base';
+
+export class PDFLibUtilsError extends PDFLibError {}
+
+const backtick = (val: any) => `\`${val}\``;
+const singleQuote = (val: any) => `'${val}'`;
+
+const formatValue = (value: any) => {
+  const type = typeof value;
+  if (type === 'string') return singleQuote(value);
+  if (type === 'undefined') return backtick(value);
+  return value;
+};
+
+const formatAllowedTypes = (types: TypeDescriptor[]) => {
+  const allowedTypes = new Array(types.length);
+
+  for (let idx = 0, len = types.length; idx < len; idx++) {
+    const type = types[idx];
+    if (type === 'null') allowedTypes[idx] = backtick('null');
+    else if (type === 'undefined') allowedTypes[idx] = backtick('undefined');
+    else if (type === 'string') allowedTypes[idx] = backtick('string');
+    else if (type === 'number') allowedTypes[idx] = backtick('number');
+    else if (type === 'boolean') allowedTypes[idx] = backtick('boolean');
+    else if (type === 'symbol') allowedTypes[idx] = backtick('symbol');
+    else if (type === 'bigint') allowedTypes[idx] = backtick('bigint');
+    else if (type === Array) allowedTypes[idx] = backtick('Array');
+    else if (type === Uint8Array) allowedTypes[idx] = backtick('Uint8Array');
+    else if (type === Uint16Array) allowedTypes[idx] = backtick('Uint16Array');
+    else if (type === Uint32Array) allowedTypes[idx] = backtick('Uint32Array');
+    else if (type === ArrayBuffer) allowedTypes[idx] = backtick('ArrayBuffer');
+    // tslint:disable-next-line:ban-types
+    else allowedTypes[idx] = backtick((type as [Function, string])[1]);
+  }
+
+  return allowedTypes.join(' or ');
+};
+
+export class InvalidInputTypeError extends PDFLibUtilsError {
+  constructor(valueName: string, expectedTypes: string, actual: any) {
+    const msg =
+      `${backtick(valueName)} must be one of ${expectedTypes}, ` +
+      `but was actually ${formatValue(actual)}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidPngError extends PDFLibUtilsError {
+  constructor(ctype: number) {
+    const msg = `Unknown color type: ${ctype}`;
+    super(PDFLibErrorTypes.INVALID_EXTERNAL_BINARY_DATA, msg);
+  }
+}
+
+export class AnimatedPngNotSupportedError extends PDFLibUtilsError {
+  constructor() {
+    super(
+      PDFLibErrorTypes.UNSUPPORTED_EXTERNAL_BINARY_DATA,
+      'Animated PNGs are not supported',
+    );
+  }
+}
+
+export class InvalidOptionPassedError extends PDFLibUtilsError {
+  constructor(valueName: string, allowedValues: Primitive[], actual: any) {
+    const allowed = allowedValues.map(formatValue).join(' or ');
+    const msg =
+      `${backtick(valueName)} must be one of ${allowed}, ` +
+      `but was actually ${formatValue(actual)}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidTypePassedError extends PDFLibUtilsError {
+  constructor(valueName: string, types: TypeDescriptor[], actual: any) {
+    const msg =
+      `${backtick(valueName)} must be of type ${formatAllowedTypes(types)}, ` +
+      `but was actually of type ${backtick(getType(actual))}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidRangePassedError extends PDFLibUtilsError {
+  constructor(valueName: string, min: number, max: number, actual: number) {
+    const msg =
+      `${backtick(valueName)} must be at least ${min} and at most ${max}, ` +
+      `but was actually ${actual}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidMultiplePassedError extends PDFLibUtilsError {
+  constructor(valueName: string, multiplier: number, actual: number) {
+    const msg =
+      `${backtick(valueName)} must be a multiple of ${multiplier}, ` +
+      `but was actually ${actual}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidIntegerPassedError extends PDFLibUtilsError {
+  constructor(valueName: string, actual: any) {
+    const msg = `${backtick(valueName)} must be an integer, but was actually ${actual}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidPositiveNumberPassedError extends PDFLibUtilsError {
+  constructor(valueName: string, actual: number) {
+    const msg =
+      `${backtick(valueName)} must be a positive number or 0, ` +
+      `but was actually ${actual}`;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}
+
+export class InvalidWordBreakError extends PDFLibUtilsError {
+  constructor(newlineUnion: string) {
+    const msg = '`wordBreak` must not include ' + newlineUnion;
+    super(PDFLibErrorTypes.INVALID_CALLER_INPUT, msg);
+  }
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from 'src/utils/errors';
 export * from 'src/utils/arrays';
 export * from 'src/utils/async';
 export * from 'src/utils/strings';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,6 @@ export * from 'src/utils/async';
 export * from 'src/utils/strings';
 export * from 'src/utils/unicode';
 export * from 'src/utils/numbers';
-export * from 'src/utils/errors';
 export * from 'src/utils/objects';
 export * from 'src/utils/validators';
 export * from 'src/utils/pdfDocEncoding';

--- a/src/utils/png.ts
+++ b/src/utils/png.ts
@@ -10,7 +10,7 @@ const getImageType = (ctype: number) => {
   if (ctype === 3) return PngType.IndexedColour;
   if (ctype === 4) return PngType.GreyscaleWithAlpha;
   if (ctype === 6) return PngType.TruecolourWithAlpha;
-  throw new InvalidPngError(ctype);
+  throw new InvalidPngError(`Unknown color type: ${ctype}`);
 };
 
 const splitAlphaChannel = (rgbaChannel: Uint8Array) => {

--- a/src/utils/png.ts
+++ b/src/utils/png.ts
@@ -4,6 +4,12 @@ import {
   InvalidPngError,
 } from 'src/utils/errors';
 
+const mapUpngError = (error: unknown, msgPrefix: string): InvalidPngError => {
+  const message =
+    error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+  return new InvalidPngError(`${msgPrefix} ${message}`);
+};
+
 const getImageType = (ctype: number) => {
   if (ctype === 0) return PngType.Greyscale;
   if (ctype === 2) return PngType.Truecolour;
@@ -52,10 +58,20 @@ export class PNG {
   readonly bitsPerComponent: number;
 
   private constructor(pngData: Uint8Array) {
-    // @ts-ignore : It internally does new Uint8Array()
-    const upng = UPNG.decode(pngData);
+    let upng: ReturnType<typeof UPNG.decode>;
+    try {
+      // @ts-ignore : It internally does new Uint8Array()
+      upng = UPNG.decode(pngData);
+    } catch (error) {
+      throw mapUpngError(error, 'Failed to decode PNG:');
+    }
 
-    const frames = UPNG.toRGBA8(upng);
+    let frames: ArrayBuffer[];
+    try {
+      frames = UPNG.toRGBA8(upng);
+    } catch (error) {
+      throw mapUpngError(error, 'Failed to convert PNG to RGBA8:');
+    }
 
     if (frames.length > 1) {
       throw new AnimatedPngNotSupportedError();

--- a/src/utils/png.ts
+++ b/src/utils/png.ts
@@ -1,4 +1,8 @@
 import UPNG from '@pdf-lib/upng';
+import {
+  AnimatedPngNotSupportedError,
+  InvalidPngError,
+} from 'src/utils/errors';
 
 const getImageType = (ctype: number) => {
   if (ctype === 0) return PngType.Greyscale;
@@ -6,7 +10,7 @@ const getImageType = (ctype: number) => {
   if (ctype === 3) return PngType.IndexedColour;
   if (ctype === 4) return PngType.GreyscaleWithAlpha;
   if (ctype === 6) return PngType.TruecolourWithAlpha;
-  throw new Error(`Unknown color type: ${ctype}`);
+  throw new InvalidPngError(ctype);
 };
 
 const splitAlphaChannel = (rgbaChannel: Uint8Array) => {
@@ -53,7 +57,9 @@ export class PNG {
 
     const frames = UPNG.toRGBA8(upng);
 
-    if (frames.length > 1) throw new Error(`Animated PNGs are not supported`);
+    if (frames.length > 1) {
+      throw new AnimatedPngNotSupportedError();
+    }
 
     const frame = new Uint8Array(frames[0]);
     const { rgbChannel, alphaChannel } = splitAlphaChannel(frame);

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,3 +1,5 @@
+import { InvalidWordBreakError } from 'src/utils/errors';
+
 export const toCharCode = (character: string) => character.charCodeAt(0);
 
 export const toCodePoint = (character: string) => character.codePointAt(0);
@@ -93,7 +95,7 @@ const buildWordBreakRegex = (wordBreaks: string[]) => {
   for (let idx = 0, len = wordBreaks.length; idx < len; idx++) {
     const wordBreak = wordBreaks[idx];
     if (isNewlineChar(wordBreak)) {
-      throw new TypeError(`\`wordBreak\` must not include ${newlineCharUnion}`);
+      throw new InvalidWordBreakError(newlineCharUnion);
     }
     escapedRules.push(wordBreak === '' ? '.' : escapeRegExp(wordBreak));
   }

--- a/src/utils/unicode.ts
+++ b/src/utils/unicode.ts
@@ -1,4 +1,7 @@
-import { toHexString } from 'src/utils/strings';
+import {
+  InvalidByteOrderError,
+  InvalidUnicodeCodePointError,
+} from 'src/core/errors';
 
 /**
  * Encodes a string to UTF-8.
@@ -130,7 +133,7 @@ export const utf8Encode = (input: string, byteOrderMark = true): Uint8Array => {
     }
 
     // Should never reach this case
-    else throw new Error(`Invalid code point: 0x${toHexString(codePoint)}`);
+    else throw new InvalidUnicodeCodePointError(codePoint);
   }
 
   return new Uint8Array(encoded);
@@ -224,7 +227,7 @@ export const utf16Encode = (
     }
 
     // Should never reach this case
-    else throw new Error(`Invalid code point: 0x${toHexString(codePoint)}`);
+    else throw new InvalidUnicodeCodePointError(codePoint);
   }
 
   return new Uint16Array(encoded);
@@ -358,7 +361,7 @@ const decodeValues = (first: number, second: number, byteOrder: ByteOrder) => {
   // the second one.
   if (byteOrder === ByteOrder.LittleEndian) return (second << 8) | first;
   if (byteOrder === ByteOrder.BigEndian) return (first << 8) | second;
-  throw new Error(`Invalid byteOrder: ${byteOrder}`);
+  throw new InvalidByteOrderError(byteOrder);
 };
 
 /**

--- a/src/utils/validators-helpers.ts
+++ b/src/utils/validators-helpers.ts
@@ -1,0 +1,54 @@
+export type Primitive = string | number | boolean | undefined | null;
+
+export type TypeDescriptor =
+  | 'null'
+  | 'undefined'
+  | 'string'
+  | 'number'
+  | 'boolean'
+  | 'symbol'
+  | 'bigint'
+  | DateConstructor
+  | ArrayConstructor
+  | Uint8ArrayConstructor
+  | Uint16ArrayConstructor
+  | Uint32ArrayConstructor
+  | ArrayBufferConstructor
+  | FunctionConstructor
+  // tslint:disable-next-line:ban-types
+  | [Function, string];
+
+export const isType = (value: any, type: TypeDescriptor) => {
+  if (type === 'null') return value === null;
+  if (type === 'undefined') return value === undefined;
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'number') return typeof value === 'number' && !isNaN(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'symbol') return typeof value === 'symbol';
+  if (type === 'bigint') return typeof value === 'bigint';
+  if (type === Date) return value instanceof Date;
+  if (type === Array) return value instanceof Array;
+  if (type === Uint8Array) return value instanceof Uint8Array;
+  if (type === Uint16Array) return value instanceof Uint16Array;
+  if (type === Uint32Array) return value instanceof Uint32Array;
+  if (type === ArrayBuffer) return value instanceof ArrayBuffer;
+  // tslint:disable-next-line:ban-types
+  if (type === Function) return value instanceof Function;
+  // tslint:disable-next-line:ban-types
+  return value instanceof (type as [Function, string])[0];
+};
+
+export const getType = (val: any) => {
+  if (val === null) return 'null';
+  if (val === undefined) return 'undefined';
+  if (typeof val === 'string') return 'string';
+  if (isNaN(val)) return 'NaN';
+  if (typeof val === 'number') return 'number';
+  if (typeof val === 'boolean') return 'boolean';
+  if (typeof val === 'symbol') return 'symbol';
+  if (typeof val === 'bigint') return 'bigint';
+  if (val.constructor && val.constructor.name) return val.constructor.name;
+  if (val.name) return val.name;
+  if (val.constructor) return String(val.constructor);
+  return String(val);
+};

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,35 +1,14 @@
+import {
+  InvalidIntegerPassedError,
+  InvalidMultiplePassedError,
+  InvalidOptionPassedError,
+  InvalidPositiveNumberPassedError,
+  InvalidRangePassedError,
+  InvalidTypePassedError,
+} from 'src/utils/errors';
 import { values as objectValues } from 'src/utils/objects';
 import type { Primitive, TypeDescriptor } from 'src/utils/validators-helpers';
 import { isType } from 'src/utils/validators-helpers';
-
-export const backtick = (val: any) => `\`${val}\``;
-export const singleQuote = (val: any) => `'${val}'`;
-
-// prettier-ignore
-const formatValue = (value: any) => {
-  const type = typeof value;
-  if (type ==='string') return singleQuote(value);
-  else if (type ==='undefined') return backtick(value);
-  else return value;
-};
-
-export const createValueErrorMsg = (
-  value: any,
-  valueName: string,
-  values: Primitive[],
-) => {
-  const allowedValues = new Array(values.length);
-
-  for (let idx = 0, len = values.length; idx < len; idx++) {
-    const v = values[idx];
-    allowedValues[idx] = formatValue(v);
-  }
-
-  const joinedValues = allowedValues.join(' or ');
-
-  // prettier-ignore
-  return `${backtick(valueName)} must be one of ${joinedValues}, but was actually ${formatValue(value)}`;
-};
 
 export const assertIsOneOf = (
   value: any,
@@ -42,7 +21,7 @@ export const assertIsOneOf = (
   for (let idx = 0, len = allowedValues.length; idx < len; idx++) {
     if (value === allowedValues[idx]) return;
   }
-  throw new TypeError(createValueErrorMsg(value, valueName, allowedValues));
+  throw new InvalidOptionPassedError(valueName, allowedValues, value);
 };
 
 export const assertIsOneOfOrUndefined = (
@@ -69,52 +48,6 @@ export const assertIsSubset = (
   }
 };
 
-export const getType = (val: any) => {
-  if (val === null) return 'null';
-  if (val === undefined) return 'undefined';
-  if (typeof val === 'string') return 'string';
-  if (isNaN(val)) return 'NaN';
-  if (typeof val === 'number') return 'number';
-  if (typeof val === 'boolean') return 'boolean';
-  if (typeof val === 'symbol') return 'symbol';
-  if (typeof val === 'bigint') return 'bigint';
-  if (val.constructor && val.constructor.name) return val.constructor.name;
-  if (val.name) return val.name;
-  if (val.constructor) return String(val.constructor);
-  return String(val);
-};
-
-export const createTypeErrorMsg = (
-  value: any,
-  valueName: string,
-  types: TypeDescriptor[],
-) => {
-  const allowedTypes = new Array(types.length);
-
-  for (let idx = 0, len = types.length; idx < len; idx++) {
-    const type = types[idx];
-    if (type === 'null') allowedTypes[idx] = backtick('null');
-    if (type === 'undefined') allowedTypes[idx] = backtick('undefined');
-    if (type === 'string') allowedTypes[idx] = backtick('string');
-    else if (type === 'number') allowedTypes[idx] = backtick('number');
-    else if (type === 'boolean') allowedTypes[idx] = backtick('boolean');
-    else if (type === 'symbol') allowedTypes[idx] = backtick('symbol');
-    else if (type === 'bigint') allowedTypes[idx] = backtick('bigint');
-    else if (type === Array) allowedTypes[idx] = backtick('Array');
-    else if (type === Uint8Array) allowedTypes[idx] = backtick('Uint8Array');
-    else if (type === Uint16Array) allowedTypes[idx] = backtick('Uint16Array');
-    else if (type === Uint32Array) allowedTypes[idx] = backtick('Uint32Array');
-    else if (type === ArrayBuffer) allowedTypes[idx] = backtick('ArrayBuffer');
-    // tslint:disable-next-line:ban-types
-    else allowedTypes[idx] = backtick((type as [Function, string])[1]);
-  }
-
-  const joinedTypes = allowedTypes.join(' or ');
-
-  // prettier-ignore
-  return `${backtick(valueName)} must be of type ${joinedTypes}, but was actually of type ${backtick(getType(value))}`;
-};
-
 export const assertIs = (
   value: any,
   valueName: string,
@@ -123,7 +56,7 @@ export const assertIs = (
   for (let idx = 0, len = types.length; idx < len; idx++) {
     if (isType(value, types[idx])) return;
   }
-  throw new TypeError(createTypeErrorMsg(value, valueName, types));
+  throw new InvalidTypePassedError(valueName, types, value);
 };
 
 export const assertOrUndefined = (
@@ -156,7 +89,7 @@ export const assertRange = (
   max = Math.max(min, max);
   if (value < min || value > max) {
     // prettier-ignore
-    throw new Error(`${backtick(valueName)} must be at least ${min} and at most ${max}, but was actually ${value}`);
+    throw new InvalidRangePassedError(valueName, min, max, value);
   }
 };
 
@@ -178,21 +111,19 @@ export const assertMultiple = (
   assertIs(value, valueName, ['number']);
   if (value % multiplier !== 0) {
     // prettier-ignore
-    throw new Error(`${backtick(valueName)} must be a multiple of ${multiplier}, but was actually ${value}`);
+    throw new InvalidMultiplePassedError(valueName, multiplier, value);
   }
 };
 
 export const assertInteger = (value: any, valueName: string) => {
   if (!Number.isInteger(value)) {
-    throw new Error(
-      `${backtick(valueName)} must be an integer, but was actually ${value}`,
-    );
+    throw new InvalidIntegerPassedError(valueName, value);
   }
 };
 
 export const assertPositive = (value: number, valueName: string) => {
   if (![1, 0].includes(Math.sign(value))) {
     // prettier-ignore
-    throw new Error(`${backtick(valueName)} must be a positive number or 0, but was actually ${value}`);
+    throw new InvalidPositiveNumberPassedError(valueName, value);
   }
 };

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,11 +1,9 @@
-/* tslint:disable:ban-types */
-
 import { values as objectValues } from 'src/utils/objects';
+import type { Primitive, TypeDescriptor } from 'src/utils/validators-helpers';
+import { isType } from 'src/utils/validators-helpers';
 
 export const backtick = (val: any) => `\`${val}\``;
 export const singleQuote = (val: any) => `'${val}'`;
-
-type Primitive = string | number | boolean | undefined | null;
 
 // prettier-ignore
 const formatValue = (value: any) => {
@@ -86,41 +84,6 @@ export const getType = (val: any) => {
   return String(val);
 };
 
-export type TypeDescriptor =
-  | 'null'
-  | 'undefined'
-  | 'string'
-  | 'number'
-  | 'boolean'
-  | 'symbol'
-  | 'bigint'
-  | DateConstructor
-  | ArrayConstructor
-  | Uint8ArrayConstructor
-  | Uint16ArrayConstructor
-  | Uint32ArrayConstructor
-  | ArrayBufferConstructor
-  | FunctionConstructor
-  | [Function, string];
-
-export const isType = (value: any, type: TypeDescriptor) => {
-  if (type === 'null') return value === null;
-  if (type === 'undefined') return value === undefined;
-  if (type === 'string') return typeof value === 'string';
-  if (type === 'number') return typeof value === 'number' && !isNaN(value);
-  if (type === 'boolean') return typeof value === 'boolean';
-  if (type === 'symbol') return typeof value === 'symbol';
-  if (type === 'bigint') return typeof value === 'bigint';
-  if (type === Date) return value instanceof Date;
-  if (type === Array) return value instanceof Array;
-  if (type === Uint8Array) return value instanceof Uint8Array;
-  if (type === Uint16Array) return value instanceof Uint16Array;
-  if (type === Uint32Array) return value instanceof Uint32Array;
-  if (type === ArrayBuffer) return value instanceof ArrayBuffer;
-  if (type === Function) return value instanceof Function;
-  return value instanceof (type as [Function, string])[0];
-};
-
 export const createTypeErrorMsg = (
   value: any,
   valueName: string,
@@ -142,6 +105,7 @@ export const createTypeErrorMsg = (
     else if (type === Uint16Array) allowedTypes[idx] = backtick('Uint16Array');
     else if (type === Uint32Array) allowedTypes[idx] = backtick('Uint32Array');
     else if (type === ArrayBuffer) allowedTypes[idx] = backtick('ArrayBuffer');
+    // tslint:disable-next-line:ban-types
     else allowedTypes[idx] = backtick((type as [Function, string])[1]);
   }
 

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -20,7 +20,10 @@ import {
   PDFPage,
   PDFFont,
 } from 'src/api';
-import { InvalidIndirectObjectError } from 'src/core/errors';
+import {
+  InvalidIndirectObjectError,
+  UnsupportedFontFileFormatError,
+} from 'src/core/errors';
 import { PDFSecurity, SecurityOptions } from 'src/core/security/PDFSecurity';
 import { readBinaryFileSync } from '../test-utils';
 
@@ -194,6 +197,14 @@ describe(`PDFDocument`, () => {
 
       expect(() => pdfDoc.embedTTFFont(ttFont, { subset: false })).toThrow(
         InvalidFontSubsetOptionError,
+      );
+    });
+
+    it(`rejects buffer data that is not a font`, async () => {
+      const pdfDoc = await PDFDocument.create({ updateMetadata: false });
+
+      expect(() => pdfDoc.embedFont(examplePngImage)).toThrow(
+        UnsupportedFontFileFormatError,
       );
     });
   });

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -2,7 +2,13 @@ import {
   AssertionError as FontkitAssertionError,
   create as createFont,
 } from '@denkiyagi/fontkit';
-import type { TTFFont } from '@denkiyagi/fontkit';
+import type {
+  BBox,
+  Glyph,
+  GlyphRun,
+  Subset,
+  TTFFont,
+} from '@denkiyagi/fontkit';
 import {
   Duplex,
   NonFullScreenPageMode,
@@ -65,40 +71,48 @@ const ubuntuFontBytes = readBinaryFileSync('assets/fonts/ubuntu/Ubuntu-B.ttf');
  * This is not a valid font—it's just enough shape to drive error mapping and guard coverage.
  */
 const makeStubTTFFont = (overrides: Partial<TTFFont> = {}): TTFFont => {
-  const glyph = {
+  const glyph: Partial<Glyph> = {
     id: 1,
     advanceWidth: 0,
     advanceHeight: 0,
     vertOriginY: 0,
-  } as any;
-  const subset = {
+  };
+  const subset: Subset = {
     type: 'TTF',
+    font: undefined as unknown as TTFFont,
+    glyphs: [],
+    mapping: {},
     includeGlyph: jest.fn().mockReturnValue(1),
     encode: jest.fn().mockReturnValue(new Uint8Array()),
-  } as any;
+  };
   const layout = jest.fn(
-    () =>
-      ({
-        glyphs: [glyph],
-        positions: null,
-        script: null,
-        language: null,
-        direction: 'ltr',
-        features: {},
-      }) as any,
-  ) as any;
+    (): Partial<GlyphRun> => ({
+      glyphs: [glyph as Glyph],
+      positions: null,
+      script: null,
+      language: null,
+      direction: 'ltr',
+      features: {},
+    }),
+  );
+  const bbox: Partial<BBox> = {
+    minX: 0,
+    minY: 0,
+    maxX: 0,
+    maxY: 0,
+  };
   const baseFont: Partial<TTFFont> = {
     type: 'TTF',
     unitsPerEm: 1000,
     postscriptName: 'FakeFont',
     characterSet: [],
-    bbox: { minX: 0, minY: 0, maxX: 0, maxY: 0 } as any,
-    head: { macStyle: { italic: false } } as any,
-    post: { isFixedPitch: false } as any,
-    layout,
-    getGlyph: jest.fn(() => glyph),
-    glyphForCodePoint: jest.fn(() => glyph),
-    createSubset: (() => subset) as unknown as TTFFont['createSubset'],
+    bbox: bbox as BBox,
+    head: { macStyle: { italic: false } },
+    post: { isFixedPitch: false },
+    layout: layout as TTFFont['layout'],
+    getGlyph: jest.fn(() => glyph as Glyph),
+    glyphForCodePoint: jest.fn(() => glyph as Glyph),
+    createSubset: (() => subset) as TTFFont['createSubset'],
     defaultVertOriginY: 0,
     cff: false,
     ascent: 0,
@@ -107,6 +121,8 @@ const makeStubTTFFont = (overrides: Partial<TTFFont> = {}): TTFFont => {
     capHeight: 0,
     xHeight: 0,
   };
+
+  subset.font = baseFont as TTFFont;
 
   return { ...baseFont, ...overrides } as TTFFont;
 };

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -14,11 +14,13 @@ import {
 } from 'src/core';
 import {
   EncryptedPDFError,
+  InvalidFontSubsetOptionError,
   ParseSpeeds,
   PDFDocument,
   PDFPage,
   PDFFont,
 } from 'src/api';
+import { InvalidIndirectObjectError } from 'src/core/errors';
 import { PDFSecurity, SecurityOptions } from 'src/core/security/PDFSecurity';
 import { readBinaryFileSync } from '../test-utils';
 
@@ -143,16 +145,13 @@ describe(`PDFDocument`, () => {
     });
 
     it(`throws an error for invalid PDFs when throwOnInvalidObject=true`, async () => {
-      const expectedError = new Error(
-        'Trying to parse invalid object: {"line":20,"column":13,"offset":126})',
-      );
       await expect(
         PDFDocument.load(invalidObjectsPdfBytes, {
           ignoreEncryption: true,
           parseSpeed: ParseSpeeds.Fastest,
           throwOnInvalidObject: true,
         }),
-      ).rejects.toEqual(expectedError);
+      ).rejects.toThrow(InvalidIndirectObjectError);
     });
   });
 
@@ -184,7 +183,9 @@ describe(`PDFDocument`, () => {
       const pdfDoc = await PDFDocument.create({ updateMetadata: false });
       const ttFont = createFont(new Uint8Array(ubuntuFontBytes)) as TTFFont;
 
-      expect(() => pdfDoc.embedTTFFont(ttFont, {})).toThrow(TypeError);
+      expect(() => pdfDoc.embedTTFFont(ttFont, {})).toThrow(
+        InvalidFontSubsetOptionError,
+      );
     });
 
     it(`rejects TTFFont instances when subset is false`, async () => {
@@ -192,7 +193,7 @@ describe(`PDFDocument`, () => {
       const ttFont = createFont(new Uint8Array(ubuntuFontBytes)) as TTFFont;
 
       expect(() => pdfDoc.embedTTFFont(ttFont, { subset: false })).toThrow(
-        TypeError,
+        InvalidFontSubsetOptionError,
       );
     });
   });

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -26,6 +26,7 @@ import {
 } from 'src/core/errors';
 import { PDFSecurity, SecurityOptions } from 'src/core/security/PDFSecurity';
 import { readBinaryFileSync } from '../test-utils';
+import { InvalidPngError } from 'src/utils';
 
 const examplePngImage = readBinaryFileSync('assets/images/etwe.png');
 
@@ -536,6 +537,14 @@ describe(`PDFDocument`, () => {
       };
 
       await expect(noErrorFunc()).resolves.not.toThrowError();
+    });
+
+    it(`throws an error when the provided data is not a PNG`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      await expect(pdfDoc.embedPng(ubuntuFontBytes)).rejects.toThrow(
+        InvalidPngError,
+      );
     });
   });
 

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -1,4 +1,7 @@
-import { create as createFont } from '@denkiyagi/fontkit';
+import {
+  AssertionError as FontkitAssertionError,
+  create as createFont,
+} from '@denkiyagi/fontkit';
 import type { TTFFont } from '@denkiyagi/fontkit';
 import {
   Duplex,
@@ -22,6 +25,7 @@ import {
 } from 'src/api';
 import {
   InvalidIndirectObjectError,
+  FontkitAssertionError as PDFLibFontkitAssertionError,
   UnsupportedFontFileFormatError,
 } from 'src/core/errors';
 import { PDFSecurity, SecurityOptions } from 'src/core/security/PDFSecurity';
@@ -55,6 +59,57 @@ const withViewerPrefsPdfBytes = readBinaryFileSync(
   'assets/pdfs/with_viewer_prefs.pdf',
 );
 const ubuntuFontBytes = readBinaryFileSync('assets/fonts/ubuntu/Ubuntu-B.ttf');
+
+/**
+ * Build a lightweight stub `TTFFont` for tests, with optional overrides for specific methods.
+ * This is not a valid font—it's just enough shape to drive error mapping and guard coverage.
+ */
+const makeStubTTFFont = (overrides: Partial<TTFFont> = {}): TTFFont => {
+  const glyph = {
+    id: 1,
+    advanceWidth: 0,
+    advanceHeight: 0,
+    vertOriginY: 0,
+  } as any;
+  const subset = {
+    type: 'TTF',
+    includeGlyph: jest.fn().mockReturnValue(1),
+    encode: jest.fn().mockReturnValue(new Uint8Array()),
+  } as any;
+  const layout = jest.fn(
+    () =>
+      ({
+        glyphs: [glyph],
+        positions: null,
+        script: null,
+        language: null,
+        direction: 'ltr',
+        features: {},
+      }) as any,
+  ) as any;
+  const baseFont: Partial<TTFFont> = {
+    type: 'TTF',
+    unitsPerEm: 1000,
+    postscriptName: 'FakeFont',
+    characterSet: [],
+    bbox: { minX: 0, minY: 0, maxX: 0, maxY: 0 } as any,
+    head: { macStyle: { italic: false } } as any,
+    post: { isFixedPitch: false } as any,
+    layout,
+    getGlyph: jest.fn(() => glyph),
+    glyphForCodePoint: jest.fn(() => glyph),
+    createSubset: (() => subset) as unknown as TTFFont['createSubset'],
+    defaultVertOriginY: 0,
+    cff: false,
+    ascent: 0,
+    descent: 0,
+    italicAngle: 0,
+    capHeight: 0,
+    xHeight: 0,
+  };
+
+  return { ...baseFont, ...overrides } as TTFFont;
+};
 
 describe(`PDFDocument`, () => {
   describe(`load() method`, () => {
@@ -206,6 +261,41 @@ describe(`PDFDocument`, () => {
 
       expect(() => pdfDoc.embedFont(examplePngImage)).toThrow(
         UnsupportedFontFileFormatError,
+      );
+    });
+
+    it(`maps fontkit errors thrown during embedding TTFFont`, async () => {
+      const pdfDoc = await PDFDocument.create({ updateMetadata: false });
+      const fontkitError = new FontkitAssertionError('boom');
+      const ttFont = makeStubTTFFont({
+        createSubset: () => {
+          throw fontkitError;
+        },
+      });
+
+      expect(() => pdfDoc.embedTTFFont(ttFont, { subset: true })).toThrow(
+        PDFLibFontkitAssertionError,
+      );
+    });
+
+    it(`maps fontkit errors thrown while encoding text`, async () => {
+      const layoutError = new FontkitAssertionError('layout fail');
+      const subset = {
+        type: 'TTF',
+        includeGlyph: jest.fn().mockReturnValue(1),
+        encode: jest.fn().mockReturnValue(new Uint8Array()),
+      };
+      const ttFont = makeStubTTFFont({
+        createSubset: (() => subset) as unknown as TTFFont['createSubset'],
+        layout: () => {
+          throw layoutError;
+        },
+      });
+      const pdfDoc = await PDFDocument.create({ updateMetadata: false });
+      const pdfFont = pdfDoc.embedTTFFont(ttFont, { subset: true });
+
+      expect(() => pdfFont.encodeText('Hi')).toThrow(
+        PDFLibFontkitAssertionError,
       );
     });
   });


### PR DESCRIPTION
## 変更概要

- 基底エラークラスの導入
    - 新規モジュール `src/core/error-base.ts` にて `PDFLibError` クラスを追加
    - 既存のエラークラスを含め、全てのエラーの基底クラスとして使用
- 生のエラーの置き換え
    - `src/api/`, `src/core/`, `src/utils/` それぞれの各種モジュールにて、生の `Error`/`TypeError` を投げていた箇所を独自のエラークラスに置き換え
    - エラークラスはそれぞれ `src/api/errors.ts`, `src/core/errors.ts`, `src/utils/errors.ts` で定義
- 外部ライブラリーの例外の捕捉
    - `@denkiyagi/fontkit` が出す例外を catch して pdf-lib のエラークラスに変換するように
        - 該当箇所: `PDFDocument` クラスの `embedFont` 系のメソッド、および `PDFFont` クラスの一部メソッド
    - `@pdf-lib/upng` が出す例外を catch して pdf-lib のエラークラスに変換するように
        - 該当箇所: `src/utils/png.ts`

## テスト

`PDFDocument.spec.ts` にて：
- 既存のテストケースにエラークラスの変更を反映
- 不正なフォントやPNGを埋め込んだ際に意図したエラーが出ることを確認するための最低限の新規テストケースを追加

## その他

`package.json` 等のバージョンを `1.17.1-mod.2025.8` に更新