### PR TITLE
publish対象のファイルが欠落しているのを修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,9 @@
-scratchpad/build/
-apps/node-build/
 node_modules/
-coverage/
-ts3.4/
-umd/
-cjs/
-es/
+
+/scratchpad/build/
+/apps/node-build/
+/coverage/
+/dist/
 
 tsBuildInfo.json
 flamegraph.html

--- a/MODIFICATIONS.md
+++ b/MODIFICATIONS.md
@@ -1,6 +1,6 @@
 # Modifications
 
-## [1.17.1-mod.2026.1]
+## [1.17.1-mod.2026.2]
 
 ### Build System Changes
 
@@ -12,6 +12,10 @@
 
 - Switched PNG decoding from `@pdf-lib/upng` to `fast-png`, preventing freezes on truncated PNG inputs.
 - Animated PNGs are now accepted and decoded as a single image.
+
+## [1.17.1-mod.2026.1]
+
+- (removed)
 
 ## [1.17.1-mod.2025.8]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@denkiyagi/pdf-lib",
-  "version": "1.17.1-mod.2026.1",
+  "version": "1.17.1-mod.2026.2",
   "description": "A modified version of pdf-lib. Create and modify PDF files with JavaScript",
   "author": "DenkiYagi Inc. (modified version author), Andrew Dillon <andrew.dillon.j@gmail.com> (orignal version author)",
   "contributors": [


### PR DESCRIPTION
`.gitignore` の更新漏れが原因として疑われるため、これを修正